### PR TITLE
Update user handler

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,23 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@lulibrary/lag-alma-utils": {
+      "version": "git+ssh://git@github.com/lulibrary/LAG-Alma-Utils.git#4ac296b9a6d43f03db1329a0d427011847f89ff4",
+      "from": "git+ssh://git@github.com/lulibrary/LAG-Alma-Utils.git#v0.4.0",
+      "requires": {
+        "dynamoose": "^0.8.7",
+        "lodash.chunk": "^4.2.0",
+        "moment": "^2.22.1"
+      }
+    },
+    "@lulibrary/lag-utils": {
+      "version": "git+ssh://git@github.com/lulibrary/LAG-Utils.git#978e4995bada3d86507ec0fcc4d75e6cb3b179c3",
+      "from": "git+ssh://git@github.com/lulibrary/LAG-Utils.git#v0.3.3",
+      "requires": {
+        "aws-sdk": "^2.223.1",
+        "eslint-plugin-mocha": "^5.0.0"
+      }
+    },
     "@sinonjs/formatio": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
@@ -100,6 +117,22 @@
       "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
       "dev": true
     },
+    "aws-sdk": {
+      "version": "2.265.1",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.265.1.tgz",
+      "integrity": "sha512-0xL9Lontx71wxwa+adZQGAWGmsXyrJbJmBzcCd6w+/zRAkd/mGX7T0V4mivPZK3QIiaKR8U/TZDmxAwnOryX3Q==",
+      "requires": {
+        "buffer": "4.9.1",
+        "events": "1.1.1",
+        "ieee754": "1.1.8",
+        "jmespath": "0.15.0",
+        "querystring": "0.2.0",
+        "sax": "1.2.1",
+        "url": "0.10.3",
+        "uuid": "3.1.0",
+        "xml2js": "0.4.17"
+      }
+    },
     "babel-code-frame": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
@@ -147,6 +180,11 @@
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
     },
+    "base64-js": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
+      "integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw=="
+    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -162,6 +200,23 @@
       "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
       "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
       "dev": true
+    },
+    "buffer": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
+      "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
+      "requires": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4",
+        "isarray": "^1.0.0"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+        }
+      }
     },
     "builtin-modules": {
       "version": "1.1.1",
@@ -372,6 +427,28 @@
         "esutils": "^2.0.2"
       }
     },
+    "dynamoose": {
+      "version": "0.8.7",
+      "resolved": "https://registry.npmjs.org/dynamoose/-/dynamoose-0.8.7.tgz",
+      "integrity": "sha512-TZuv+5a5tq4ZpHYgtxic72o4IJjw0fBeeLCEVS5MLDZevARmb79mIaV/AY8vKWP7wxrkRAWXIF4mfg0NHas9Vg==",
+      "requires": {
+        "aws-sdk": "^2.80.0",
+        "debug": "^2.6.8",
+        "hooks": "0.3.2",
+        "lodash": "^4.17.4",
+        "q": "^1.5.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
     "error-ex": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
@@ -505,6 +582,12 @@
         }
       }
     },
+    "eslint-plugin-chai-friendly": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-chai-friendly/-/eslint-plugin-chai-friendly-0.4.1.tgz",
+      "integrity": "sha512-hkpLN7VVoGGsofZjUhcQ+sufC3FgqMJwD0DvAcRfxY1tVRyQyVsqpaKnToPHJQOrRo0FQ0fSEDwW2gr4rsNdGA==",
+      "dev": true
+    },
     "eslint-plugin-import": {
       "version": "2.13.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.13.0.tgz",
@@ -548,6 +631,14 @@
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "dev": true
         }
+      }
+    },
+    "eslint-plugin-mocha": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-mocha/-/eslint-plugin-mocha-5.0.0.tgz",
+      "integrity": "sha512-mpRWWsjxRco2bY4qE5DL8SmGoVF0Onb6DZrbgOjFoNo1YNN299K2voIozd8Kce3qC/neWNr2XF27E1ZDMl1yZg==",
+      "requires": {
+        "ramda": "^0.25.0"
       }
     },
     "eslint-plugin-node": {
@@ -635,6 +726,11 @@
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
       "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
       "dev": true
+    },
+    "events": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+      "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
     },
     "external-editor": {
       "version": "2.2.0",
@@ -730,6 +826,12 @@
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
       "dev": true
     },
+    "get-caller-file": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
+      "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=",
+      "dev": true
+    },
     "get-func-name": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
@@ -818,6 +920,11 @@
       "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
       "dev": true
     },
+    "hooks": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/hooks/-/hooks-0.3.2.tgz",
+      "integrity": "sha1-ox8GDCAmzqbPHKPrF4Qw5xjhxKM="
+    },
     "hosted-git-info": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.6.1.tgz",
@@ -832,6 +939,11 @@
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
       }
+    },
+    "ieee754": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz",
+      "integrity": "sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q="
     },
     "ignore": {
       "version": "3.3.10",
@@ -978,6 +1090,11 @@
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
     },
+    "jmespath": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
+      "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
+    },
     "js-tokens": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
@@ -1055,8 +1172,12 @@
     "lodash": {
       "version": "4.17.10",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
-      "dev": true
+      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
+    },
+    "lodash.chunk": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.chunk/-/lodash.chunk-4.2.0.tgz",
+      "integrity": "sha1-ZuXOH3btJ7QwPYxlEujRIW6BBrw="
     },
     "lodash.get": {
       "version": "4.4.2",
@@ -1119,11 +1240,25 @@
         "supports-color": "5.4.0"
       }
     },
+    "mock-require": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mock-require/-/mock-require-3.0.2.tgz",
+      "integrity": "sha512-aD/Y1ZFHqw5pHg3HVQ50dLbfaAAcytS6sqLuhP51Dk3TSPdFb2VkSAa3mjrHifLIlGAtwQHJHINafAyqAne7vA==",
+      "dev": true,
+      "requires": {
+        "get-caller-file": "^1.0.2",
+        "normalize-path": "^2.1.1"
+      }
+    },
+    "moment": {
+      "version": "2.22.2",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.22.2.tgz",
+      "integrity": "sha1-PCV/mDn8DpP/UxSWMiOeuQeD/2Y="
+    },
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-      "dev": true
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "mute-stream": {
       "version": "0.0.7",
@@ -1166,6 +1301,15 @@
         "is-builtin-module": "^1.0.0",
         "semver": "2 || 3 || 4 || 5",
         "validate-npm-package-license": "^3.0.1"
+      }
+    },
+    "normalize-path": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+      "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+      "dev": true,
+      "requires": {
+        "remove-trailing-separator": "^1.0.1"
       }
     },
     "nyc": {
@@ -3992,6 +4136,21 @@
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
       "dev": true
     },
+    "q": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
+      "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc="
+    },
+    "querystring": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
+    },
+    "ramda": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.25.0.tgz",
+      "integrity": "sha512-GXpfrYVPwx3K7RQ6aYT8KPS8XViSXUVJT1ONhoKPE9VAleW42YE+U+8VEyGWt41EnEQW7gwecYJriTI0pKoecQ=="
+    },
     "read-pkg": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
@@ -4037,6 +4196,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-1.1.0.tgz",
       "integrity": "sha512-LOPw8FpgdQF9etWMaAfG/WRthIdXJGYp4mJ2Jgn/2lpkbod9jPn0t9UqN7AxBOKNfzRbYyVfgc7Vk4t/MpnXgw==",
+      "dev": true
+    },
+    "remove-trailing-separator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
       "dev": true
     },
     "require-uncached": {
@@ -4112,6 +4277,11 @@
       "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.3.0.tgz",
       "integrity": "sha512-1HwIYD/8UlOtFS3QO3w7ey+SdSDFE4HRNLZoZRYVQefrOY3l17epswImeB1ijgJFQJodIaHcwkp3r/myBjFVbg==",
       "dev": true
+    },
+    "sax": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
+      "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o="
     },
     "semver": {
       "version": "5.5.0",
@@ -4340,6 +4510,27 @@
         "punycode": "^2.1.0"
       }
     },
+    "url": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+      "integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
+      "requires": {
+        "punycode": "1.3.2",
+        "querystring": "0.2.0"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+          "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
+        }
+      }
+    },
+    "uuid": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
+      "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g=="
+    },
     "validate-npm-package-license": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.3.tgz",
@@ -4378,6 +4569,23 @@
       "dev": true,
       "requires": {
         "mkdirp": "^0.5.1"
+      }
+    },
+    "xml2js": {
+      "version": "0.4.17",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.17.tgz",
+      "integrity": "sha1-F76T6q4/O3eTWceVtBlwWogX6Gg=",
+      "requires": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "^4.1.0"
+      }
+    },
+    "xmlbuilder": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-4.2.1.tgz",
+      "integrity": "sha1-qlijBBoGb5DqoWwvU4n/GfP0YaU=",
+      "requires": {
+        "lodash": "^4.0.0"
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -71,8 +71,8 @@
       "dev": true
     },
     "alma-api-wrapper": {
-      "version": "git+ssh://git@github.com/lulibrary/node-alma-api-wrapper.git#c8ab2b4b6f80c73b03c2ffd58006253df0ed2a58",
-      "from": "git+ssh://git@github.com/lulibrary/node-alma-api-wrapper.git#users-class",
+      "version": "git+ssh://git@github.com/lulibrary/node-alma-api-wrapper.git#fa1b9aac24baaaeb563235af97a54a77ba9322a7",
+      "from": "git+ssh://git@github.com/lulibrary/node-alma-api-wrapper.git#v0.1.0",
       "requires": {
         "axios": "^0.18.0",
         "lodash.merge": "^4.6.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,11 +14,12 @@
       }
     },
     "@lulibrary/lag-utils": {
-      "version": "git+ssh://git@github.com/lulibrary/LAG-Utils.git#978e4995bada3d86507ec0fcc4d75e6cb3b179c3",
-      "from": "git+ssh://git@github.com/lulibrary/LAG-Utils.git#v0.3.3",
+      "version": "git+ssh://git@github.com/lulibrary/LAG-Utils.git#e886fbc1c8a7513964e6e7784a147ceacd53ec48",
+      "from": "git+ssh://git@github.com/lulibrary/LAG-Utils.git#queue-methods",
       "requires": {
         "aws-sdk": "^2.223.1",
-        "eslint-plugin-mocha": "^5.0.0"
+        "eslint-plugin-mocha": "^5.0.0",
+        "lodash.merge": "^4.6.1"
       }
     },
     "@sinonjs/formatio": {
@@ -29,6 +30,12 @@
       "requires": {
         "samsam": "1.3.0"
       }
+    },
+    "@sinonjs/samsam": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-2.0.0.tgz",
+      "integrity": "sha512-D7VxhADdZbDJ0HjUTMnSQ5xIGb4H2yWpg8k9Sf1T08zfFiQYlaxM8LZydpR4FQ2E6LZJX8IlabNZ5io4vdChwg==",
+      "dev": true
     },
     "acorn": {
       "version": "5.7.1",
@@ -62,6 +69,14 @@
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.2.0.tgz",
       "integrity": "sha1-6GuBnGAs+IIa1jdBNpjx3sAhhHo=",
       "dev": true
+    },
+    "alma-api-wrapper": {
+      "version": "git+ssh://git@github.com/lulibrary/node-alma-api-wrapper.git#c8ab2b4b6f80c73b03c2ffd58006253df0ed2a58",
+      "from": "git+ssh://git@github.com/lulibrary/node-alma-api-wrapper.git#users-class",
+      "requires": {
+        "axios": "^0.18.0",
+        "lodash.merge": "^4.6.1"
+      }
     },
     "ansi-escapes": {
       "version": "3.1.0",
@@ -131,6 +146,44 @@
         "url": "0.10.3",
         "uuid": "3.1.0",
         "xml2js": "0.4.17"
+      }
+    },
+    "aws-sdk-mock": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk-mock/-/aws-sdk-mock-4.0.0.tgz",
+      "integrity": "sha512-wW79xLFuinT4pXVCql3sokddHGaEyG7sM8rCV5CTmaemxG/w2T0dN9Z6mAg5J2ZnnJLa8kkO2lg7ltd6U05ihA==",
+      "dev": true,
+      "requires": {
+        "aws-sdk": "^2.260.1",
+        "sinon": "^6.0.0",
+        "traverse": "^0.6.6"
+      },
+      "dependencies": {
+        "sinon": {
+          "version": "6.1.3",
+          "resolved": "https://registry.npmjs.org/sinon/-/sinon-6.1.3.tgz",
+          "integrity": "sha512-yeTza8xIZZdiXntCHJAzKll/sSYE+DuJOS8hiSapzaLqdW8eCNVVC9je9SZYYTkPm2bLts9x6UYxwuMAVVrM6Q==",
+          "dev": true,
+          "requires": {
+            "@sinonjs/formatio": "^2.0.0",
+            "@sinonjs/samsam": "^2.0.0",
+            "diff": "^3.5.0",
+            "lodash.get": "^4.4.2",
+            "lolex": "^2.4.2",
+            "nise": "^1.3.3",
+            "supports-color": "^5.4.0",
+            "type-detect": "^4.0.8"
+          }
+        }
+      }
+    },
+    "axios": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.18.0.tgz",
+      "integrity": "sha1-MtU+SFHv3AoRmTts0AB4nXDAUQI=",
+      "requires": {
+        "follow-redirects": "^1.3.0",
+        "is-buffer": "^1.1.5"
       }
     },
     "babel-code-frame": {
@@ -217,6 +270,12 @@
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
         }
       }
+    },
+    "buffer-from": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.0.tgz",
+      "integrity": "sha512-c5mRlguI/Pe2dSZmpER62rSCu0ryKmWddzRYsuXc50U2/g8jMOulc31VZMa4mYx31U5xsmSOpDCgH88Vl9cDGQ==",
+      "dev": true
     },
     "builtin-modules": {
       "version": "1.1.1",
@@ -317,6 +376,12 @@
       "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
       "dev": true
     },
+    "co": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+      "dev": true
+    },
     "color-convert": {
       "version": "1.9.2",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.2.tgz",
@@ -344,10 +409,28 @@
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
+    "concat-stream": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+      "dev": true,
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
+      }
+    },
     "contains-path": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",
       "integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=",
+      "dev": true
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
     },
     "cross-spawn": {
@@ -367,7 +450,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
       "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-      "dev": true,
       "requires": {
         "ms": "2.0.0"
       }
@@ -802,6 +884,14 @@
         "write": "^0.2.1"
       }
     },
+    "follow-redirects": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.1.tgz",
+      "integrity": "sha512-v9GI1hpaqq1ZZR6pBD1+kI7O24PhDvNGNodjS3MdcEqyrahCp8zbtpv+2B/krUnSmUH80lbAS7MrdeK5IylgKg==",
+      "requires": {
+        "debug": "^3.1.0"
+      }
+    },
     "foreach": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
@@ -1000,6 +1090,11 @@
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
       "dev": true
     },
+    "is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+    },
     "is-builtin-module": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
@@ -1185,11 +1280,26 @@
       "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
       "dev": true
     },
+    "lodash.merge": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.1.tgz",
+      "integrity": "sha512-AOYza4+Hf5z1/0Hztxpm2/xiPZgi/cjMqdnKTUWTBSKchJlxXXuUSxCCl8rJlf4g6yww/j6mA8nC8Hw/EZWxKQ=="
+    },
     "lolex": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.7.0.tgz",
       "integrity": "sha512-uJkH2e0BVfU5KOJUevbTOtpDduooSarH5PopO+LfM/vZf8Z9sJzODqKev804JYM2i++ktJfUmC1le4LwFQ1VMg==",
       "dev": true
+    },
+    "lru-cache": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
+      "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
+      "dev": true,
+      "requires": {
+        "pseudomap": "^1.0.2",
+        "yallist": "^2.1.2"
+      }
     },
     "mimic-fn": {
       "version": "1.2.0",
@@ -4124,10 +4234,22 @@
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
       "dev": true
     },
+    "process-nextick-args": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+      "dev": true
+    },
     "progress": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.0.tgz",
       "integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8=",
+      "dev": true
+    },
+    "pseudomap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
       "dev": true
     },
     "punycode": {
@@ -4180,6 +4302,29 @@
           "requires": {
             "locate-path": "^2.0.0"
           }
+        }
+      }
+    },
+    "readable-stream": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+      "dev": true,
+      "requires": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "dev": true
         }
       }
     },
@@ -4239,6 +4384,177 @@
         "signal-exit": "^3.0.2"
       }
     },
+    "rewire": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/rewire/-/rewire-4.0.1.tgz",
+      "integrity": "sha512-+7RQ/BYwTieHVXetpKhT11UbfF6v1kGhKFrtZN7UDL2PybMsSt/rpLWeEUGF5Ndsl1D5BxiCB14VDJyoX+noYw==",
+      "dev": true,
+      "requires": {
+        "eslint": "^4.19.1"
+      },
+      "dependencies": {
+        "acorn-jsx": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
+          "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
+          "dev": true,
+          "requires": {
+            "acorn": "^3.0.4"
+          },
+          "dependencies": {
+            "acorn": {
+              "version": "3.3.0",
+              "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
+              "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
+              "dev": true
+            }
+          }
+        },
+        "ajv": {
+          "version": "5.5.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+          "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+          "dev": true,
+          "requires": {
+            "co": "^4.6.0",
+            "fast-deep-equal": "^1.0.0",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.3.0"
+          }
+        },
+        "ajv-keywords": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.1.tgz",
+          "integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I=",
+          "dev": true
+        },
+        "cross-spawn": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+          "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^4.0.1",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
+          }
+        },
+        "eslint": {
+          "version": "4.19.1",
+          "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.19.1.tgz",
+          "integrity": "sha512-bT3/1x1EbZB7phzYu7vCr1v3ONuzDtX8WjuM9c0iYxe+cq+pwcKEoQjl7zd3RpC6YOLgnSy3cTN58M2jcoPDIQ==",
+          "dev": true,
+          "requires": {
+            "ajv": "^5.3.0",
+            "babel-code-frame": "^6.22.0",
+            "chalk": "^2.1.0",
+            "concat-stream": "^1.6.0",
+            "cross-spawn": "^5.1.0",
+            "debug": "^3.1.0",
+            "doctrine": "^2.1.0",
+            "eslint-scope": "^3.7.1",
+            "eslint-visitor-keys": "^1.0.0",
+            "espree": "^3.5.4",
+            "esquery": "^1.0.0",
+            "esutils": "^2.0.2",
+            "file-entry-cache": "^2.0.0",
+            "functional-red-black-tree": "^1.0.1",
+            "glob": "^7.1.2",
+            "globals": "^11.0.1",
+            "ignore": "^3.3.3",
+            "imurmurhash": "^0.1.4",
+            "inquirer": "^3.0.6",
+            "is-resolvable": "^1.0.0",
+            "js-yaml": "^3.9.1",
+            "json-stable-stringify-without-jsonify": "^1.0.1",
+            "levn": "^0.3.0",
+            "lodash": "^4.17.4",
+            "minimatch": "^3.0.2",
+            "mkdirp": "^0.5.1",
+            "natural-compare": "^1.4.0",
+            "optionator": "^0.8.2",
+            "path-is-inside": "^1.0.2",
+            "pluralize": "^7.0.0",
+            "progress": "^2.0.0",
+            "regexpp": "^1.0.1",
+            "require-uncached": "^1.0.3",
+            "semver": "^5.3.0",
+            "strip-ansi": "^4.0.0",
+            "strip-json-comments": "~2.0.1",
+            "table": "4.0.2",
+            "text-table": "~0.2.0"
+          }
+        },
+        "eslint-scope": {
+          "version": "3.7.1",
+          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.1.tgz",
+          "integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
+          "dev": true,
+          "requires": {
+            "esrecurse": "^4.1.0",
+            "estraverse": "^4.1.1"
+          }
+        },
+        "espree": {
+          "version": "3.5.4",
+          "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
+          "integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
+          "dev": true,
+          "requires": {
+            "acorn": "^5.5.0",
+            "acorn-jsx": "^3.0.0"
+          }
+        },
+        "fast-deep-equal": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+          "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
+          "dev": true
+        },
+        "inquirer": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
+          "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
+          "dev": true,
+          "requires": {
+            "ansi-escapes": "^3.0.0",
+            "chalk": "^2.0.0",
+            "cli-cursor": "^2.1.0",
+            "cli-width": "^2.0.0",
+            "external-editor": "^2.0.4",
+            "figures": "^2.0.0",
+            "lodash": "^4.3.0",
+            "mute-stream": "0.0.7",
+            "run-async": "^2.2.0",
+            "rx-lite": "^4.0.8",
+            "rx-lite-aggregates": "^4.0.8",
+            "string-width": "^2.1.0",
+            "strip-ansi": "^4.0.0",
+            "through": "^2.3.6"
+          }
+        },
+        "json-schema-traverse": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+          "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
+          "dev": true
+        },
+        "table": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/table/-/table-4.0.2.tgz",
+          "integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
+          "dev": true,
+          "requires": {
+            "ajv": "^5.2.3",
+            "ajv-keywords": "^2.1.0",
+            "chalk": "^2.1.0",
+            "lodash": "^4.17.4",
+            "slice-ansi": "1.0.0",
+            "string-width": "^2.1.1"
+          }
+        }
+      }
+    },
     "rimraf": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
@@ -4257,6 +4573,21 @@
         "is-promise": "^2.1.0"
       }
     },
+    "rx-lite": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
+      "integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ=",
+      "dev": true
+    },
+    "rx-lite-aggregates": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
+      "integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
+      "dev": true,
+      "requires": {
+        "rx-lite": "*"
+      }
+    },
     "rxjs": {
       "version": "5.5.11",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.11.tgz",
@@ -4265,6 +4596,12 @@
       "requires": {
         "symbol-observable": "1.0.1"
       }
+    },
+    "safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
     },
     "safer-buffer": {
       "version": "2.1.2",
@@ -4401,6 +4738,15 @@
         "regexp.prototype.flags": "^1.2.0"
       }
     },
+    "string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "strip-ansi": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
@@ -4486,6 +4832,12 @@
         "os-tmpdir": "~1.0.2"
       }
     },
+    "traverse": {
+      "version": "0.6.6",
+      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
+      "integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc=",
+      "dev": true
+    },
     "type-check": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
@@ -4499,6 +4851,12 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
       "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true
+    },
+    "typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
     },
     "uri-js": {
@@ -4525,6 +4883,12 @@
           "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
         }
       }
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
     },
     "uuid": {
       "version": "3.1.0",
@@ -4587,6 +4951,12 @@
       "requires": {
         "lodash": "^4.0.0"
       }
+    },
+    "yallist": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+      "dev": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -21,13 +21,20 @@
     "chai-as-promised": "^7.1.1",
     "eslint": "^5.0.1",
     "eslint-config-standard": "^11.0.0",
+    "eslint-plugin-chai-friendly": "^0.4.1",
     "eslint-plugin-import": "^2.13.0",
+    "eslint-plugin-mocha": "^5.0.0",
     "eslint-plugin-node": "^6.0.1",
     "eslint-plugin-promise": "^3.8.0",
     "eslint-plugin-standard": "^3.1.0",
     "mocha": "^5.0.5",
+    "mock-require": "^3.0.2",
     "nyc": "^11.6.0",
     "sinon": "^5.0.2",
     "sinon-chai": "^3.0.0"
+  },
+  "dependencies": {
+    "@lulibrary/lag-alma-utils": "git+ssh://git@github.com/lulibrary/LAG-Alma-Utils.git#v0.4.0",
+    "@lulibrary/lag-utils": "git+ssh://git@github.com/lulibrary/LAG-Utils.git#v0.3.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -38,6 +38,6 @@
   "dependencies": {
     "@lulibrary/lag-alma-utils": "git+ssh://git@github.com/lulibrary/LAG-Alma-Utils.git#v0.4.0",
     "@lulibrary/lag-utils": "git+ssh://git@github.com/lulibrary/LAG-Utils.git#queue-methods",
-    "alma-api-wrapper": "git+ssh://git@github.com/lulibrary/node-alma-api-wrapper.git#users-class"
+    "alma-api-wrapper": "git+ssh://git@github.com/lulibrary/node-alma-api-wrapper.git#v0.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "homepage": "https://github.com/lulibrary/LAG-bulk-update-cache#readme",
   "devDependencies": {
+    "aws-sdk-mock": "^4.0.0",
     "chai": "^4.1.2",
     "chai-as-promised": "^7.1.1",
     "eslint": "^5.0.1",
@@ -30,11 +31,13 @@
     "mocha": "^5.0.5",
     "mock-require": "^3.0.2",
     "nyc": "^11.6.0",
+    "rewire": "^4.0.1",
     "sinon": "^5.0.2",
     "sinon-chai": "^3.0.0"
   },
   "dependencies": {
     "@lulibrary/lag-alma-utils": "git+ssh://git@github.com/lulibrary/LAG-Alma-Utils.git#v0.4.0",
-    "@lulibrary/lag-utils": "git+ssh://git@github.com/lulibrary/LAG-Utils.git#v0.3.3"
+    "@lulibrary/lag-utils": "git+ssh://git@github.com/lulibrary/LAG-Utils.git#queue-methods",
+    "alma-api-wrapper": "git+ssh://git@github.com/lulibrary/node-alma-api-wrapper.git#users-class"
   }
 }

--- a/serverless.yml
+++ b/serverless.yml
@@ -5,7 +5,83 @@ provider:
   runtime: nodejs6.10
   region: ${opt:region}
   stage: ${opt:stage}
+  iamRoleStatements:
+    - Effect: Allow
+      Action:
+        - sqs:SendMessage
+        - sqs:GetQueueURL
+        - sqs:ReceiveMessage
+        - sqs:DeleteMessage
+      Resource:
+        - ${self:custom.QueueArns.${opt:stage}.usersQueue}
+        - ${self:custom.QueueArns.${opt:stage}.loansQueue}
+        - ${self:custom.QueueArns.${opt:stage}.requestsQueue}
+    - Effect: Allow
+      Action:
+        - dynamodb:GetItem
+        - dynamodb:PutItem
+        - dynamodb:DeleteItem
+        - dynamodb:DescribeTable
+      Resource:
+        - ${self:custom.TableArns.${opt:stage}.userCacheTable}
 
 functions:
   updateUser:
     handler: src/update-user/handler.handle
+    events:
+      - sqs: ${self:custom.QueueArns.${opt:stage}.usersQueue}
+    environment:
+      USERS_QUEUE_URL: ${self:custom.QueueUrls.${opt:stage}.usersQueue}
+      LOANS_QUEUE_URL: ${self:custom.QueueUrls.${opt:stage}.loansQueue}
+      REQUESTS_QUEUE_URL: ${self:custom.QueueUrls.${opt:stage}.requestsQueue}
+      USER_CACHE_TABLE: ${self:custom.TableNames.${opt:stage}.userCacheTable}
+      ALMA_KEY: ${env:ALMA_API_KEY}
+resources:
+  Resources:
+    loansQueue:
+      Type: AWS::SQS::Queue
+      Properties:
+        QueueName: ${self:service}-${opt:stage}-loansQueue
+    requestsQueue:
+      Type: AWS::SQS::Queue
+      Properties:
+        QueueName: ${self:service}-${opt:stage}-requestsQueue
+
+custom:
+  TableArns:
+    stg:
+      userCacheTable: ${env:USER_CACHE_TABLE_ARN_STG}
+    prod:
+      userCacheTable: ${env:USER_CACHE_TABLE_ARN_PROD}
+  TableNames:
+    stg:
+      userCacheTable: ${env:USER_CACHE_TABLE_NAME_STG}
+    prod:
+      userCacheTable: ${env:USER_CACHE_TABLE_NAME_PROD}
+  QueueArns:
+    stg:
+      usersQueue: ${env:USER_QUEUE_ARN_STG}
+      loansQueue:
+        "Fn::GetAtt": ["loansQueue", "Arn"]
+      requestsQueue:
+        "Fn::GetAtt": ["requestsQueue", "Arn"]
+    prod:
+      usersQueue: ${env:USER_QUEUE_ARN_PROD}
+      loansQueue:
+        "Fn::GetAtt": ["loansQueue", "Arn"]
+      requestsQueue:
+        "Fn::GetAtt": ["requestsQueue", "Arn"]
+
+  QueueUrls:
+    stg:
+      usersQueue: ${env:USER_QUEUE_URL_STG}
+      loansQueue:
+        Ref: loansQueue
+      requestsQueue:
+        Ref: requestsQueue
+    prod:
+      usersQueue: ${env:USER_QUEUE_URL_PROD}
+      loansQueue:
+        Ref: loansQueue
+      requestsQueue:
+        Ref: requestsQueue

--- a/src/update-user/create-user-from-api.js
+++ b/src/update-user/create-user-from-api.js
@@ -1,0 +1,32 @@
+
+const AlmaClient = require('alma-api-wrapper')
+const { UserSchema } = require('@lulibrary/lag-alma-utils')
+const User = UserSchema(process.env.USER_CACHE_TABLE)
+
+const createUserFromApi = (userID) => getUserData(userID).then(createUser)
+
+const getUserData = (userID) => {
+  const almaApi = new AlmaClient()
+  const apiUser = almaApi.users.for(userID)
+  return Promise.all([
+    apiUser.loans(),
+    apiUser.requests()
+  ])
+    .then(data => {
+      return {
+        id: userID,
+        loans: data[0],
+        requests: data[1]
+      }
+    })
+}
+
+const createUser = (userData) => {
+  return User.create({
+    primary_id: userData.id,
+    loan_ids: Array.from(userData.loans.keys()),
+    request_ids: Array.from(userData.requests.keys())
+  })
+}
+
+module.exports = createUserFromApi

--- a/src/update-user/create-user-from-api.js
+++ b/src/update-user/create-user-from-api.js
@@ -1,9 +1,9 @@
 
 const AlmaClient = require('alma-api-wrapper')
 const { UserSchema } = require('@lulibrary/lag-alma-utils')
-const User = UserSchema(process.env.USER_CACHE_TABLE)
+const CacheUser = UserSchema(process.env.USER_CACHE_TABLE)
 
-const createUserFromApi = (userID) => getUserData(userID).then(createUser)
+const createUserFromApi = (userID) => getUserData(userID).then(createUserInCache)
 
 const getUserData = (userID) => {
   const almaApi = new AlmaClient()
@@ -21,8 +21,8 @@ const getUserData = (userID) => {
     })
 }
 
-const createUser = (userData) => {
-  return User.create({
+const createUserInCache = (userData) => {
+  return CacheUser.create({
     primary_id: userData.id,
     loan_ids: Array.from(userData.loans.keys()),
     request_ids: Array.from(userData.requests.keys())

--- a/src/update-user/handler.js
+++ b/src/update-user/handler.js
@@ -1,16 +1,44 @@
-'use strict';
+'use strict'
+const almaApi = require('@lulibrary/node-alma-api')
+const { User } = require('@lulibrary/lag-alma-utils')
+const { Queue } = require('@lulibrary/lag-utils')
 
 module.exports.handle = (event, context, callback) => {
-  const response = {
-    statusCode: 200,
-    body: JSON.stringify({
-      message: 'Go Serverless v1.0! Your function executed successfully!',
-      input: event,
-    }),
-  };
-
-  callback(null, response);
+  fetchUsersFromQueue()
+    .then(userIDs => {
+      return Promise.all(userIDs.map(updateUser))
+        .then(user => {
+          return Promise.all([
+            sendLoanIDsToQueue(user.loan_ids)
+          ])
+        })
+    })
 
   // Use this code if you don't use the http event with the LAMBDA-PROXY integration
   // callback(null, { message: 'Go Serverless v1.0! Your function executed successfully!', event });
-};
+}
+
+const updateUser = (userID) => {
+  return Promise.all([
+    almaApi.users.for(userID).loans.get()
+  ])
+    .then(results => {
+      return {
+        primary_id: userID,
+        loans: results[0]
+      }
+    })
+    .then(userData => {
+      User.create(userData)
+    })
+}
+
+const sendLoanIDsToQueue = (loanIDs) => {
+  const loansQueue = new Queue({})
+
+  return Promise.all(loanIDs.map(loansQueue.sendMessage))
+}
+
+const fetchUsersFromQueue = () => {
+
+}

--- a/src/update-user/send-to-queue.js
+++ b/src/update-user/send-to-queue.js
@@ -1,0 +1,8 @@
+const { Queue } = require('@lulibrary/lag-utils')
+
+const sendMessagesToQueue = (url, messages) => {
+  const targetQueue = new Queue({ url })
+  return Promise.all(messages.map((message) => targetQueue.sendMessage(message)))
+}
+
+module.exports = sendMessagesToQueue

--- a/test/create-user-from-api-test.js
+++ b/test/create-user-from-api-test.js
@@ -1,0 +1,157 @@
+const sinon = require('sinon')
+const sandbox = sinon.createSandbox()
+
+const chai = require('chai')
+const sinonChai = require('sinon-chai')
+const chaiAsPromised = require('chai-as-promised')
+chai.use(sinonChai)
+chai.use(chaiAsPromised)
+chai.should()
+
+const uuid = require('uuid')
+
+// Dynamoose
+process.env.USER_CACHE_TABLE = uuid()
+const { UserSchema } = require('@lulibrary/lag-alma-utils')
+const User = UserSchema(process.env.USER_CACHE_TABLE)
+
+// Alma API
+const AlmaClient = require('alma-api-wrapper')
+const AlmaApiUser = require('alma-api-wrapper/src/user')
+
+const rewire = require('rewire')
+let wires = []
+
+// Module under test
+const createUserFromApi = rewire('../src/update-user/create-user-from-api')
+
+describe('create-user-from-api tests', () => {
+  afterEach(() => {
+    sandbox.restore()
+    wires.forEach(wire => wire())
+    wires = []
+  })
+
+  describe('createUser method tests', () => {
+    it('should call User#create', () => {
+      const createStub = sandbox.stub(User, 'create')
+      createStub.resolves()
+      const createUser = createUserFromApi.__get__('createUser')
+
+      const testUserID = uuid()
+
+      const testUserData = {
+        id: testUserID,
+        loans: new Map(),
+        requests: new Map()
+      }
+
+      return createUser(testUserData)
+        .then((testUser) => {
+          createUser
+          createStub.should.have.been.calledWith({
+            primary_id: testUserID,
+            loan_ids: [],
+            request_ids: []
+          })
+        })
+    })
+
+    it('should create arrays of the loan and request IDs', () => {
+      const createStub = sandbox.stub(User, 'create')
+      createStub.resolves()
+      const createUser = createUserFromApi.__get__('createUser')
+
+      const testUserID = uuid()
+
+      const loanIDs = [uuid(), uuid(), uuid()]
+      const requestIDs = [uuid(), uuid(), uuid()]
+
+      const testUserData = {
+        id: testUserID,
+        loans: new Map(loanIDs.map(id => [id, null])),
+        requests: new Map(requestIDs.map(id => [id, null]))
+      }
+
+      return createUser(testUserData)
+        .then((testUser) => {
+          createStub.should.have.been.calledWith({
+            primary_id: testUserID,
+            loan_ids: loanIDs,
+            request_ids: requestIDs
+          })
+        })
+    })
+  })
+
+  describe('getUserData method tests', () => {
+    const getData = createUserFromApi.__get__('getUserData')
+    before(() => {
+      process.env.ALMA_KEY = uuid()
+    })
+
+    after(() => {
+      delete process.env.ALMA_KEY
+    })
+
+    it('should call apiUser#loans and apiUser#requests', () => {
+      const loansStub = sandbox.stub(AlmaApiUser.prototype, 'loans')
+      const requestsStub = sandbox.stub(AlmaApiUser.prototype, 'requests')
+      loansStub.resolves()
+      requestsStub.resolves()
+
+      const testUserID = uuid()
+
+      return getData(testUserID)
+        .then(() => {
+          loansStub.should.have.been.calledOnce
+          requestsStub.should.have.been.calledOnce
+        })
+    })
+
+    it('should return Loan and Request Maps from the API responses', () => {
+      const testLoans = new Map([uuid(), uuid(), uuid()].map(id => [id, uuid()]))
+      const testRequests = new Map([uuid(), uuid(), uuid()].map(id => [id, uuid()]))
+      const loansStub = sandbox.stub(AlmaApiUser.prototype, 'loans')
+      const requestsStub = sandbox.stub(AlmaApiUser.prototype, 'requests')
+      loansStub.resolves(testLoans)
+      requestsStub.resolves(testRequests)
+
+      const testUserID = uuid()
+
+      return getData(testUserID)
+        .then(userData => {
+          userData.loans.should.deep.equal(testLoans)
+          userData.requests.should.deep.equal(testRequests)
+        })
+    })
+  })
+
+  describe('createUserFromApi method tests', () => {
+    it('should call createUser with the result of getUserData', () => {
+      const testUserID = uuid()
+      const testLoans = new Map([uuid(), uuid(), uuid()].map(id => [id, uuid()]))
+      const testRequests = new Map([uuid(), uuid(), uuid()].map(id => [id, uuid()]))
+
+      const getDataStub = sandbox.stub()
+      const createUserStub = sandbox.stub()
+      wires.push(createUserFromApi.__set__('getUserData', getDataStub))
+      wires.push(createUserFromApi.__set__('createUser', createUserStub))
+      getDataStub.resolves({
+        id: testUserID,
+        loans: testLoans,
+        requests: testRequests
+      })
+      createUserStub.resolves()
+
+      return createUserFromApi(testUserID)
+        .then(() => {
+          createUserStub.should.have.been.calledWith({
+            id: testUserID,
+            loans: testLoans,
+            requests: testRequests
+          })
+        })
+    })
+  })
+})

--- a/test/update-user-test/create-user-from-api-test.js
+++ b/test/update-user-test/create-user-from-api-test.js
@@ -23,7 +23,7 @@ const rewire = require('rewire')
 let wires = []
 
 // Module under test
-const createUserFromApi = rewire('../src/update-user/create-user-from-api')
+const createUserFromApi = rewire('../../src/update-user/create-user-from-api')
 
 describe('create-user-from-api tests', () => {
   afterEach(() => {
@@ -36,7 +36,7 @@ describe('create-user-from-api tests', () => {
     it('should call User#create', () => {
       const createStub = sandbox.stub(User, 'create')
       createStub.resolves()
-      const createUser = createUserFromApi.__get__('createUser')
+      const createUser = createUserFromApi.__get__('createUserInCache')
 
       const testUserID = uuid()
 
@@ -60,7 +60,7 @@ describe('create-user-from-api tests', () => {
     it('should create arrays of the loan and request IDs', () => {
       const createStub = sandbox.stub(User, 'create')
       createStub.resolves()
-      const createUser = createUserFromApi.__get__('createUser')
+      const createUser = createUserFromApi.__get__('createUserInCache')
 
       const testUserID = uuid()
 
@@ -128,7 +128,7 @@ describe('create-user-from-api tests', () => {
   })
 
   describe('createUserFromApi method tests', () => {
-    it('should call createUser with the result of getUserData', () => {
+    it('should call createUserInCache with the result of getUserData', () => {
       const testUserID = uuid()
       const testLoans = new Map([uuid(), uuid(), uuid()].map(id => [id, uuid()]))
       const testRequests = new Map([uuid(), uuid(), uuid()].map(id => [id, uuid()]))
@@ -136,7 +136,7 @@ describe('create-user-from-api tests', () => {
       const getDataStub = sandbox.stub()
       const createUserStub = sandbox.stub()
       wires.push(createUserFromApi.__set__('getUserData', getDataStub))
-      wires.push(createUserFromApi.__set__('createUser', createUserStub))
+      wires.push(createUserFromApi.__set__('createUserInCache', createUserStub))
       getDataStub.resolves({
         id: testUserID,
         loans: testLoans,

--- a/test/update-user-test/handler-test.js
+++ b/test/update-user-test/handler-test.js
@@ -20,7 +20,7 @@ const { Queue } = require('@lulibrary/lag-utils')
 const updateUserHandler = rewire('../../src/update-user/handler')
 const handler = (event = {}, ctx = {}) => new Promise((resolve, reject) => {
   updateUserHandler.handle(event, ctx, (err, res) => {
-    err ? reject(err) : resolve(res)
+    return err ? reject(err) : resolve(res)
   })
 })
 

--- a/test/update-user-test/handler-test.js
+++ b/test/update-user-test/handler-test.js
@@ -1,19 +1,301 @@
+// Test libraries
 const sinon = require('sinon')
 const sandbox = sinon.createSandbox()
-const mockRequire = require('mock-require')
-
-mockRequire('@lulibrary/node-alma-api', {
-
-})
 
 const chai = require('chai')
+const sinonChai = require('sinon-chai')
+const chaiAsPromised = require('chai-as-promised')
+chai.use(sinonChai)
+chai.use(chaiAsPromised)
 chai.should()
+const uuid = require('uuid')
+
+const rewire = require('rewire')
+let wires = []
+
+// Module Libraries
+const { Queue } = require('@lulibrary/lag-utils')
 
 // Module under test
-const updateUserHandler = require('../../src/update-user/handler')
+const updateUserHandler = rewire('../../src/update-user/handler')
+const handler = (event = {}, ctx = {}) => new Promise((resolve, reject) => {
+  updateUserHandler.handle(event, ctx, (err, res) => {
+    err ? reject(err) : resolve(res)
+  })
+})
 
 describe('update user handler tests', () => {
+  afterEach(() => {
+    sandbox.restore()
+    wires.forEach(wire => wire())
+    wires = []
+  })
   it('should export a handler function', () => {
     updateUserHandler.handle.should.be.an.instanceOf(Function)
+  })
+
+  describe('handler method tests', () => {
+    it('should call receiveMessages on the Users Queue', () => {
+      const receiveMessagesStub = sandbox.stub(Queue.prototype, 'receiveMessages')
+      receiveMessagesStub.resolves(true)
+
+      wires.push(
+        updateUserHandler.__set__('handleMessages', () => Promise.resolve()),
+        updateUserHandler.__set__('updateUser', () => Promise.resolve()),
+        updateUserHandler.__set__('handleLoansAndRequests', () => Promise.resolve()),
+        updateUserHandler.__set__('deleteMessage', () => Promise.resolve())
+      )
+
+      return handler()
+        .then(() => {
+          receiveMessagesStub.should.have.been.called
+        })
+    })
+
+    it('should call handleMessages with the response of recieveMesages', () => {
+      const receiveMessagesStub = sandbox.stub(Queue.prototype, 'receiveMessages')
+      receiveMessagesStub.resolves([{
+        Body: 'test_message_body',
+        ReceiptHandle: 'test_message_handle'
+      }])
+
+      const handleMessageStub = sandbox.stub()
+      handleMessageStub.resolves()
+
+      wires.push(
+        updateUserHandler.__set__('handleMessages', handleMessageStub),
+        updateUserHandler.__set__('updateUser', () => Promise.resolve()),
+        updateUserHandler.__set__('handleLoansAndRequests', () => Promise.resolve()),
+        updateUserHandler.__set__('deleteMessage', () => Promise.resolve())
+      )
+
+      return handler()
+        .then(() => {
+          handleMessageStub.should.have.been.calledWith([{
+            Body: 'test_message_body',
+            ReceiptHandle: 'test_message_handle'
+          }])
+        })
+    })
+  })
+
+  describe('handleMessages method tests', () => {
+    it('should call updateUser with each message body', () => {
+      const testUserIDs = [uuid(), uuid(), uuid()]
+      const testMessages = [{
+        Body: testUserIDs[0],
+        ReceiptHandle: uuid()
+      }, {
+        Body: testUserIDs[1],
+        ReceiptHandle: uuid()
+      }, {
+        Body: testUserIDs[2],
+        ReceiptHandle: uuid()
+      }]
+
+      const receiveMessagesStub = sandbox.stub(Queue.prototype, 'receiveMessages')
+      receiveMessagesStub.resolves(testMessages)
+
+      const updateUserStub = sandbox.stub()
+      updateUserStub.resolves()
+
+      wires.push(
+        updateUserHandler.__set__('updateUser', updateUserStub),
+        updateUserHandler.__set__('handleLoansAndRequests', () => Promise.resolve()),
+        updateUserHandler.__set__('deleteMessage', () => Promise.resolve())
+      )
+
+      return handler()
+        .then(() => {
+          testMessages.forEach(message => {
+            updateUserStub.should.have.been.calledWith(message.Body)
+          })
+        })
+    })
+
+    it('should call deleteMessage with each message object', () => {
+      const testReceiptHandles = [uuid(), uuid(), uuid()]
+      const testMessages = [{
+        Body: uuid(),
+        ReceiptHandle: testReceiptHandles[0]
+      }, {
+        Body: uuid(),
+        ReceiptHandle: testReceiptHandles[1]
+      }, {
+        Body: uuid(),
+        ReceiptHandle: testReceiptHandles[2]
+      }]
+
+      const receiveMessagesStub = sandbox.stub(Queue.prototype, 'receiveMessages')
+      receiveMessagesStub.resolves(testMessages)
+
+      const deleteMessageStub = sandbox.stub()
+      deleteMessageStub.resolves()
+
+      wires.push(
+        updateUserHandler.__set__('updateUser', () => Promise.resolve()),
+        updateUserHandler.__set__('handleLoansAndRequests', () => Promise.resolve()),
+        updateUserHandler.__set__('deleteMessage', deleteMessageStub)
+      )
+
+      return handler()
+        .then(() => {
+          testMessages.forEach(message => {
+            deleteMessageStub.should.have.been.calledWith(message)
+          })
+        })
+    })
+  })
+
+  describe('updateUser method tests', () => {
+    const updateUser = updateUserHandler.__get__('updateUser')
+
+    it('should call createUserFromApi with the user ID', () => {
+      const createUserStub = sandbox.stub()
+      createUserStub.resolves()
+
+      wires.push(
+        updateUserHandler.__set__('handleLoansAndRequests', () => Promise.resolve()),
+        updateUserHandler.__set__('createUserFromApi', createUserStub)
+      )
+
+      const testUserID = uuid()
+
+      return updateUser(testUserID)
+        .then(() => {
+          createUserStub.should.have.been.calledWith(testUserID)
+        })
+    })
+
+    it('should call handleLoansAndRequests with the result of createUserFromApi', () => {
+      const createUserStub = sandbox.stub()
+      const testUser = {
+        primary_id: uuid(),
+        loan_ids: [uuid(), uuid()],
+        request_ids: [uuid(), uuid(), uuid()]
+      }
+      createUserStub.resolves(testUser)
+
+      const handleLsAndRsStub = sandbox.stub()
+      handleLsAndRsStub.resolves()
+
+      wires.push(
+        updateUserHandler.__set__('handleLoansAndRequests', handleLsAndRsStub),
+        updateUserHandler.__set__('createUserFromApi', createUserStub)
+      )
+
+      const testUserID = uuid()
+
+      return updateUser(testUserID)
+        .then(() => {
+          handleLsAndRsStub.should.have.been.calledWith(testUser)
+        })
+    })
+  })
+
+  describe('handleLoansAndRequests method tests', () => {
+    before(() => {
+      process.env.LOANS_QUEUE_URL = uuid()
+      process.env.REQUESTS_QUEUE_URL = uuid()
+    })
+
+    after(() => {
+      delete process.env.LOANS_QUEUE_URL
+      delete process.env.REQUESTS_QUEUE_URL
+    })
+    const handleLoansAndRequests = updateUserHandler.__get__('handleLoansAndRequests')
+
+    it('should call sendToQueue with the Loans Queue URL and the loan IDs', () => {
+      const sendToQueueStub = sandbox.stub()
+      sendToQueueStub.resolves()
+
+      wires.push(
+        updateUserHandler.__set__('sendToQueue', sendToQueueStub)
+      )
+
+      const testUserID = uuid()
+      const testLoans = [uuid(), uuid(), uuid(), uuid()]
+
+      const testUser = {
+        primary_id: testUserID,
+        loan_ids: testLoans,
+        request_ids: []
+      }
+
+      const expected = [{
+        loanID: testLoans[0],
+        userID: testUserID
+      }, {
+        loanID: testLoans[1],
+        userID: testUserID
+      }, {
+        loanID: testLoans[2],
+        userID: testUserID
+      }, {
+        loanID: testLoans[3],
+        userID: testUserID
+      }].map(JSON.stringify)
+
+      return handleLoansAndRequests(testUser)
+        .then(() => {
+          sendToQueueStub.should.have.been.calledWith(process.env.LOANS_QUEUE_URL, expected)
+        })
+    })
+
+    it('should call sendToQueue with the Requests Queue URL and the request IDs', () => {
+      const sendToQueueStub = sandbox.stub()
+      sendToQueueStub.resolves()
+
+      wires.push(
+        updateUserHandler.__set__('sendToQueue', sendToQueueStub)
+      )
+
+      const testUserID = uuid()
+      const testRequests = [uuid(), uuid(), uuid(), uuid()]
+
+      const testUser = {
+        primary_id: testUserID,
+        request_ids: testRequests,
+        loan_ids: []
+      }
+
+      const expected = [{
+        requestID: testRequests[0],
+        userID: testUserID
+      }, {
+        requestID: testRequests[1],
+        userID: testUserID
+      }, {
+        requestID: testRequests[2],
+        userID: testUserID
+      }, {
+        requestID: testRequests[3],
+        userID: testUserID
+      }].map(JSON.stringify)
+
+      return handleLoansAndRequests(testUser)
+        .then(() => {
+          sendToQueueStub.should.have.been.calledWith(process.env.REQUESTS_QUEUE_URL, expected)
+        })
+    })
+  })
+
+  describe('deleteMessage method tests', () => {
+    const deleteMessage = updateUserHandler.__get__('deleteMessage')
+    it('should call deleteMessage on the users Queue', () => {
+      const deleteMessageStub = sandbox.stub(Queue.prototype, 'deleteMessage')
+      deleteMessageStub.resolves()
+
+      const testHandle = uuid()
+
+      const testMessage = {
+        ReceiptHandle: testHandle
+      }
+
+      return deleteMessage(testMessage)
+        .then(() => {
+          deleteMessageStub.should.have.been.calledWith(testHandle)
+        })
+    })
   })
 })

--- a/test/update-user-test/handler-test.js
+++ b/test/update-user-test/handler-test.js
@@ -1,3 +1,11 @@
+const sinon = require('sinon')
+const sandbox = sinon.createSandbox()
+const mockRequire = require('mock-require')
+
+mockRequire('@lulibrary/node-alma-api', {
+
+})
+
 const chai = require('chai')
 chai.should()
 

--- a/test/update-user-test/send-to-queue-test.js
+++ b/test/update-user-test/send-to-queue-test.js
@@ -1,0 +1,34 @@
+// Test libraries
+const sinon = require('sinon')
+const sandbox = sinon.createSandbox()
+
+const chai = require('chai')
+const sinonChai = require('sinon-chai')
+const chaiAsPromised = require('chai-as-promised')
+chai.use(sinonChai)
+chai.use(chaiAsPromised)
+chai.should()
+
+const uuid = require('uuid')
+
+const { Queue } = require('@lulibrary/lag-utils')
+
+// Module under test
+const sendMessagesToQueue = require('../../src/update-user/send-to-queue')
+
+describe('send messages to Queue module tests', () => {
+  describe('sendMessagesToQueue method tests', () => {
+    it('should call Queue#sendMessage for each message', () => {
+      const testMessages = [uuid(), uuid(), uuid(), uuid()]
+      const sendMessageStub = sandbox.stub(Queue.prototype, 'sendMessage')
+      sendMessageStub.resolves()
+
+      return sendMessagesToQueue(uuid(), testMessages)
+        .then(() => {
+          testMessages.forEach(message => {
+            sendMessageStub.should.have.been.calledWith(message)
+          })
+        })
+    })
+  })
+})


### PR DESCRIPTION
This adds a handler for messages on the `Users` SQS Queue, which updates the cache with data from Alma for the corresponding user, and pushes IDs for all `Loans` and `Requests` to SQS queues for separate updating.