### PR TITLE
Update loan handler

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -24,6 +24,7 @@ provider:
         - dynamodb:DescribeTable
       Resource:
         - ${self:custom.TableArns.${opt:stage}.userCacheTable}
+        - ${self:custom.TableArns.${opt:stage}.loanCacheTable}
 
 functions:
   updateUser:
@@ -35,6 +36,14 @@ functions:
       LOANS_QUEUE_URL: ${self:custom.QueueUrls.${opt:stage}.loansQueue}
       REQUESTS_QUEUE_URL: ${self:custom.QueueUrls.${opt:stage}.requestsQueue}
       USER_CACHE_TABLE: ${self:custom.TableNames.${opt:stage}.userCacheTable}
+      ALMA_KEY: ${env:ALMA_API_KEY}
+  updateLoan:
+    handler: src/update-loan/handler.handle
+    events:
+      - sqs: ${self:custom.QueueArns.${opt:stage}.loansQueue}
+    environment:
+      LOANS_QUEUE_URL: ${self:custom.QueueUrls.${opt:stage}.loansQueue}
+      LOAN_CACHE_TABLE: ${self:custom.TableNames.${opt:stage}.userCacheTable}
       ALMA_KEY: ${env:ALMA_API_KEY}
 resources:
   Resources:
@@ -51,13 +60,17 @@ custom:
   TableArns:
     stg:
       userCacheTable: ${env:USER_CACHE_TABLE_ARN_STG}
+      loanCacheTable: ${env:LOAN_CACHE_TABLE_ARN_STG}
     prod:
       userCacheTable: ${env:USER_CACHE_TABLE_ARN_PROD}
+      loanCacheTable: ${env:LOAN_CACHE_TABLE_ARN_PROD}
   TableNames:
     stg:
       userCacheTable: ${env:USER_CACHE_TABLE_NAME_STG}
+      loanCacheTable: ${env:LOAN_CACHE_TABLE_NAME_STG}
     prod:
       userCacheTable: ${env:USER_CACHE_TABLE_NAME_PROD}
+      loanCacheTable: ${env:LOAN_CACHE_TABLE_NAME_PROD}
   QueueArns:
     stg:
       usersQueue: ${env:USER_QUEUE_ARN_STG}

--- a/src/update-loan/create-loan-from-api.js
+++ b/src/update-loan/create-loan-from-api.js
@@ -1,0 +1,15 @@
+
+const AlmaClient = require('alma-api-wrapper')
+const { LoanSchema } = require('@lulibrary/lag-alma-utils')
+const CacheLoan = LoanSchema(process.env.LOAN_CACHE_TABLE)
+
+const createLoanFromApi = (userID, loanID) => getLoanData(userID, loanID).then(createLoanInCache)
+
+const getLoanData = (userID, loanID) => {
+  const almaApi = new AlmaClient()
+  return almaApi.users.for(userID).getLoan(loanID)
+}
+
+const createLoanInCache = (loan) => CacheLoan.create(loan.data)
+
+module.exports = createLoanFromApi

--- a/src/update-loan/handler.js
+++ b/src/update-loan/handler.js
@@ -1,0 +1,34 @@
+'use strict'
+const { Queue } = require('@lulibrary/lag-utils')
+
+const createLoanFromApi = require('./create-loan-from-api')
+
+const loansQueue = new Queue({
+  url: process.env.LOANS_QUEUE_URL
+})
+
+module.exports.handle = (event, context, callback) => {
+  loansQueue.receiveMessages()
+    .then(handleMessages)
+    .then(() => {
+      callback(null, 'Successfully updated loans cache')
+    })
+    .catch(e => {
+      console.log(e)
+      callback(new Error('An error has occured'))
+    })
+}
+
+const handleMessages = (messages) => {
+  return Promise.all(
+    messages.map((message) => updateLoan(...JSON.parse(message.Body)))
+      .concat(messages.map(deleteMessage)))
+}
+
+const updateLoan = (userID, loanID) => {
+  return createLoanFromApi(userID, loanID)
+}
+
+const deleteMessage = (message) => {
+  return loansQueue.deleteMessage(message.ReceiptHandle)
+}

--- a/src/update-loan/handler.js
+++ b/src/update-loan/handler.js
@@ -19,9 +19,9 @@ module.exports.handle = (event, context, callback) => {
     })
 }
 
-const handleMessages = (messages) => {
+const handleMessages = (messages = []) => {
   return Promise.all(
-    messages.map((message) => updateLoan(...JSON.parse(message.Body)))
+    messages.map((message) => updateLoan(message.Body))
       .concat(messages.map(deleteMessage)))
 }
 

--- a/src/update-loan/handler.js
+++ b/src/update-loan/handler.js
@@ -22,13 +22,13 @@ module.exports.handle = (event, context, callback) => {
 const handleMessages = (messages = []) => {
   return Promise.all(
     messages.map((message) =>
-      updateLoan(message.Body)
+      updateLoan(JSON.parse(message.Body))
         .then(() => deleteMessage(message))
     ))
 }
 
-const updateLoan = (userID, loanID) => {
-  return createLoanFromApi(userID, loanID)
+const updateLoan = (IDs) => {
+  return createLoanFromApi(IDs.userID, IDs.loanID)
 }
 
 const deleteMessage = (message) => {

--- a/src/update-loan/handler.js
+++ b/src/update-loan/handler.js
@@ -21,8 +21,10 @@ module.exports.handle = (event, context, callback) => {
 
 const handleMessages = (messages = []) => {
   return Promise.all(
-    messages.map((message) => updateLoan(message.Body))
-      .concat(messages.map(deleteMessage)))
+    messages.map((message) =>
+      updateLoan(message.Body)
+        .then(() => deleteMessage(message))
+    ))
 }
 
 const updateLoan = (userID, loanID) => {

--- a/test/update-loan-test/create-loan-from-api-test.js
+++ b/test/update-loan-test/create-loan-from-api-test.js
@@ -1,0 +1,111 @@
+const sinon = require('sinon')
+const sandbox = sinon.createSandbox()
+
+const chai = require('chai')
+const sinonChai = require('sinon-chai')
+const chaiAsPromised = require('chai-as-promised')
+chai.use(sinonChai)
+chai.use(chaiAsPromised)
+chai.should()
+
+const uuid = require('uuid')
+
+// Dynamoose
+process.env.LOAN_CACHE_TABLE = uuid()
+const { LoanSchema } = require('@lulibrary/lag-alma-utils')
+const Loan = LoanSchema(process.env.LOAN_CACHE_TABLE)
+
+// Alma API
+const AlmaApiUser = require('alma-api-wrapper/src/user')
+
+const rewire = require('rewire')
+let wires = []
+
+// Module under test
+const createLoanFromApi = rewire('../../src/update-loan/create-loan-from-api')
+
+describe('create-loan-from-api tests', () => {
+  afterEach(() => {
+    sandbox.restore()
+    wires.forEach(wire => wire())
+    wires = []
+  })
+
+  describe('createLoan method tests', () => {
+    it('should call Loan#create', () => {
+      const createStub = sandbox.stub(Loan, 'create')
+      createStub.resolves()
+      const createLoan = createLoanFromApi.__get__('createLoanInCache')
+
+      const testLoanID = uuid()
+
+      const testLoanData = { data: {
+        loan_id: testLoanID,
+        title: 'test_loan_title',
+        user_id: 'test_user_id'
+      }}
+
+      return createLoan(testLoanData)
+        .then((testLoan) => {
+          createStub.should.have.been.calledWith({
+            loan_id: testLoanID,
+            title: 'test_loan_title',
+            user_id: 'test_user_id'
+          })
+        })
+    })
+  })
+
+  describe('getLoanData method tests', () => {
+    const getData = createLoanFromApi.__get__('getLoanData')
+    before(() => {
+      process.env.ALMA_KEY = uuid()
+    })
+
+    after(() => {
+      delete process.env.ALMA_KEY
+    })
+
+    it('should call apiUser#getLoan', () => {
+      const getLoanStub = sandbox.stub(AlmaApiUser.prototype, 'getLoan')
+      getLoanStub.resolves()
+
+      const testUserID = uuid()
+      const testLoanID = uuid()
+
+      return getData(testUserID, testLoanID)
+        .then(() => {
+          getLoanStub.should.have.been.calledOnce
+          getLoanStub.should.have.been.calledWith(testLoanID)
+        })
+    })
+  })
+
+  describe('createLoanFromApi method tests', () => {
+    it('should call createLoanInCache with the result of getLoanData', () => {
+      const testLoanID = uuid()
+      const testTitle = `test_title_${uuid()}`
+      const testUserID = uuid()
+
+      const getDataStub = sandbox.stub()
+      const createLoanStub = sandbox.stub()
+      wires.push(createLoanFromApi.__set__('getLoanData', getDataStub))
+      wires.push(createLoanFromApi.__set__('createLoanInCache', createLoanStub))
+      getDataStub.resolves({
+        id: testLoanID,
+        title: testTitle,
+        user_id: testUserID
+      })
+      createLoanStub.resolves()
+
+      return createLoanFromApi(testLoanID)
+        .then(() => {
+          createLoanStub.should.have.been.calledWith({
+            id: testLoanID,
+            title: testTitle,
+            user_id: testUserID
+          })
+        })
+    })
+  })
+})

--- a/test/update-loan-test/handler-test.js
+++ b/test/update-loan-test/handler-test.js
@@ -1,0 +1,214 @@
+// Test libraries
+const sinon = require('sinon')
+const sandbox = sinon.createSandbox()
+
+const chai = require('chai')
+const sinonChai = require('sinon-chai')
+const chaiAsPromised = require('chai-as-promised')
+chai.use(sinonChai)
+chai.use(chaiAsPromised)
+chai.should()
+const uuid = require('uuid')
+
+const rewire = require('rewire')
+let wires = []
+
+// Module Libraries
+const { Queue } = require('@lulibrary/lag-utils')
+
+// Module under test
+const updateLoanHandler = rewire('../../src/update-loan/handler')
+const handler = (event = {}, ctx = {}) => new Promise((resolve, reject) => {
+  updateLoanHandler.handle(event, ctx, (err, res) => {
+    return err ? reject(err) : resolve(res)
+  })
+})
+
+describe('update loan handler tests', () => {
+  afterEach(() => {
+    sandbox.restore()
+    wires.forEach(wire => wire())
+    wires = []
+  })
+  it('should export a handler function', () => {
+    updateLoanHandler.handle.should.be.an.instanceOf(Function)
+  })
+
+  describe('handler method tests', () => {
+    it('should call receiveMessages on the Loans Queue', () => {
+      const receiveMessagesStub = sandbox.stub(Queue.prototype, 'receiveMessages')
+      receiveMessagesStub.resolves(true)
+
+      wires.push(
+        updateLoanHandler.__set__('handleMessages', () => Promise.resolve()),
+        updateLoanHandler.__set__('updateLoan', () => Promise.resolve()),
+        updateLoanHandler.__set__('deleteMessage', () => Promise.resolve())
+      )
+
+      return handler()
+        .then(() => {
+          receiveMessagesStub.should.have.been.called
+        })
+    })
+
+    it('should call handleMessages with the response of recieveMesages', () => {
+      const receiveMessagesStub = sandbox.stub(Queue.prototype, 'receiveMessages')
+      receiveMessagesStub.resolves([{
+        Body: 'test_message_body',
+        ReceiptHandle: 'test_message_handle'
+      }])
+
+      const handleMessageStub = sandbox.stub()
+      handleMessageStub.resolves()
+
+      wires.push(
+        updateLoanHandler.__set__('handleMessages', handleMessageStub),
+        updateLoanHandler.__set__('updateLoan', () => Promise.resolve()),
+        updateLoanHandler.__set__('deleteMessage', () => Promise.resolve())
+      )
+
+      return handler()
+        .then(() => {
+          handleMessageStub.should.have.been.calledWith([{
+            Body: 'test_message_body',
+            ReceiptHandle: 'test_message_handle'
+          }])
+        })
+    })
+
+    it('should callback with an error if handleMessages is rejected', () => {
+      sandbox.stub(Queue.prototype, 'receiveMessages').resolves()
+      const handleMessageStub = sandbox.stub()
+      handleMessageStub.rejects()
+      wires.push(updateLoanHandler.__set__('handleMessages', handleMessageStub))
+      sandbox.stub(console, 'log')
+
+      return handler().should.eventually.be.rejectedWith('An error has occured')
+    })
+  })
+
+  describe('handleMessages method tests', () => {
+    const handleMessages = updateLoanHandler.__get__('handleMessages')
+
+    it('should call updateLoan with each message body', () => {
+      const testLoanIDs = [uuid(), uuid(), uuid()]
+      const testMessages = [{
+        Body: testLoanIDs[0],
+        ReceiptHandle: uuid()
+      }, {
+        Body: testLoanIDs[1],
+        ReceiptHandle: uuid()
+      }, {
+        Body: testLoanIDs[2],
+        ReceiptHandle: uuid()
+      }]
+
+      // const receiveMessagesStub = sandbox.stub(Queue.prototype, 'receiveMessages')
+      // receiveMessagesStub.resolves(testMessages)
+
+      const updateLoanStub = sandbox.stub()
+      updateLoanStub.resolves()
+
+      wires.push(
+        updateLoanHandler.__set__('updateLoan', updateLoanStub),
+        updateLoanHandler.__set__('deleteMessage', () => Promise.resolve())
+      )
+
+      return handleMessages(testMessages)
+        .then(() => {
+          testMessages.forEach(message => {
+            updateLoanStub.should.have.been.calledWith(message.Body)
+          })
+        })
+    })
+
+    it('should call deleteMessage with each message object', () => {
+      const testReceiptHandles = [uuid(), uuid(), uuid()]
+      const testMessages = [{
+        Body: uuid(),
+        ReceiptHandle: testReceiptHandles[0]
+      }, {
+        Body: uuid(),
+        ReceiptHandle: testReceiptHandles[1]
+      }, {
+        Body: uuid(),
+        ReceiptHandle: testReceiptHandles[2]
+      }]
+
+      // const receiveMessagesStub = sandbox.stub(Queue.prototype, 'receiveMessages')
+      // receiveMessagesStub.resolves(testMessages)
+
+      const deleteMessageStub = sandbox.stub()
+      deleteMessageStub.resolves()
+
+      wires.push(
+        updateLoanHandler.__set__('updateLoan', () => Promise.resolve()),
+        updateLoanHandler.__set__('deleteMessage', deleteMessageStub)
+      )
+
+      return handleMessages(testMessages)
+        .then(() => {
+          testMessages.forEach(message => {
+            deleteMessageStub.should.have.been.calledWith(message)
+          })
+        })
+    })
+
+    it('should default to an empty message array, and not call updateLoan or deleteMessage', () => {
+      const updateLoanStub = sandbox.stub()
+      updateLoanStub.resolves()
+      const deleteMessageStub = sandbox.stub()
+      deleteMessageStub.resolves()
+
+      wires.push(
+        updateLoanHandler.__set__('updateLoan', updateLoanStub),
+        updateLoanHandler.__set__('deleteMessage', deleteMessageStub)
+      )
+
+      return handleMessages()
+        .then(() => {
+          updateLoanStub.should.not.have.been.called
+          deleteMessageStub.should.not.have.been.called
+        })
+    })
+  })
+
+  describe('updateLoan method tests', () => {
+    const updateLoan = updateLoanHandler.__get__('updateLoan')
+
+    it('should call createLoanFromApi with the Loan ID', () => {
+      const createLoanStub = sandbox.stub()
+      createLoanStub.resolves()
+
+      wires.push(
+        updateLoanHandler.__set__('createLoanFromApi', createLoanStub)
+      )
+
+      const testLoanID = uuid()
+
+      return updateLoan(testLoanID)
+        .then(() => {
+          createLoanStub.should.have.been.calledWith(testLoanID)
+        })
+    })
+  })
+
+  describe('deleteMessage method tests', () => {
+    const deleteMessage = updateLoanHandler.__get__('deleteMessage')
+    it('should call deleteMessage on the loans Queue', () => {
+      const deleteMessageStub = sandbox.stub(Queue.prototype, 'deleteMessage')
+      deleteMessageStub.resolves()
+
+      const testHandle = uuid()
+
+      const testMessage = {
+        ReceiptHandle: testHandle
+      }
+
+      return deleteMessage(testMessage)
+        .then(() => {
+          deleteMessageStub.should.have.been.calledWith(testHandle)
+        })
+    })
+  })
+})

--- a/test/update-loan-test/handler-test.js
+++ b/test/update-loan-test/handler-test.js
@@ -54,7 +54,7 @@ describe('update loan handler tests', () => {
     it('should call handleMessages with the response of recieveMesages', () => {
       const receiveMessagesStub = sandbox.stub(Queue.prototype, 'receiveMessages')
       receiveMessagesStub.resolves([{
-        Body: 'test_message_body',
+        Body: JSON.stringify({ test: 'test_id' }),
         ReceiptHandle: 'test_message_handle'
       }])
 
@@ -70,7 +70,7 @@ describe('update loan handler tests', () => {
       return handler()
         .then(() => {
           handleMessageStub.should.have.been.calledWith([{
-            Body: 'test_message_body',
+            Body: JSON.stringify({ test: 'test_id' }),
             ReceiptHandle: 'test_message_handle'
           }])
         })
@@ -92,14 +92,15 @@ describe('update loan handler tests', () => {
 
     it('should call updateLoan with each message body', () => {
       const testLoanIDs = [uuid(), uuid(), uuid()]
+      const testBodies = testLoanIDs.map(id => JSON.stringify({ loanID: id }))
       const testMessages = [{
-        Body: testLoanIDs[0],
+        Body: testBodies[0],
         ReceiptHandle: uuid()
       }, {
-        Body: testLoanIDs[1],
+        Body: testBodies[1],
         ReceiptHandle: uuid()
       }, {
-        Body: testLoanIDs[2],
+        Body: testBodies[2],
         ReceiptHandle: uuid()
       }]
 
@@ -116,8 +117,8 @@ describe('update loan handler tests', () => {
 
       return handleMessages(testMessages)
         .then(() => {
-          testMessages.forEach(message => {
-            updateLoanStub.should.have.been.calledWith(message.Body)
+          testLoanIDs.forEach(id => {
+            updateLoanStub.should.have.been.calledWith({ loanID: id })
           })
         })
     })
@@ -125,13 +126,13 @@ describe('update loan handler tests', () => {
     it('should call deleteMessage with each message object', () => {
       const testReceiptHandles = [uuid(), uuid(), uuid()]
       const testMessages = [{
-        Body: uuid(),
+        Body: JSON.stringify({ id: uuid() }),
         ReceiptHandle: testReceiptHandles[0]
       }, {
-        Body: uuid(),
+        Body: JSON.stringify({ id: uuid() }),
         ReceiptHandle: testReceiptHandles[1]
       }, {
-        Body: uuid(),
+        Body: JSON.stringify({ id: uuid() }),
         ReceiptHandle: testReceiptHandles[2]
       }]
 
@@ -184,11 +185,12 @@ describe('update loan handler tests', () => {
         updateLoanHandler.__set__('createLoanFromApi', createLoanStub)
       )
 
+      const testUserID = uuid()
       const testLoanID = uuid()
 
-      return updateLoan(testLoanID)
+      return updateLoan({ userID: testUserID, loanID: testLoanID })
         .then(() => {
-          createLoanStub.should.have.been.calledWith(testLoanID)
+          createLoanStub.should.have.been.calledWith(testUserID, testLoanID)
         })
     })
   })


### PR DESCRIPTION
This adds a handler for messages on the Loans SQS Queue, which updates the cache with data from Alma for the corresponding loan.