### PR TITLE
Fix SQS event trigger

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -35,9 +35,9 @@ functions:
   updateUser:
     handler: src/update-user/handler.handle
     events:
-      - sqs: ${self:custom.QueueArns.${opt:stage}.usersQueue}
+      - sqs: 
+          arn: ${self:custom.QueueArns.${opt:stage}.usersQueue}
     environment:
-      USERS_QUEUE_URL: ${self:custom.QueueUrls.${opt:stage}.usersQueue}
       LOANS_QUEUE_URL: ${self:custom.QueueUrls.${opt:stage}.loansQueue}
       REQUESTS_QUEUE_URL: ${self:custom.QueueUrls.${opt:stage}.requestsQueue}
       USER_CACHE_TABLE: ${self:custom.TableNames.${opt:stage}.usersCacheTable}
@@ -45,9 +45,9 @@ functions:
   updateLoan:
     handler: src/update-loan/handler.handle
     events:
-      - sqs: ${self:custom.QueueArns.${opt:stage}.loansQueue}
+      - sqs:
+          arn: ${self:custom.QueueArns.${opt:stage}.loansQueue}
     environment:
-      LOANS_QUEUE_URL: ${self:custom.QueueUrls.${opt:stage}.loansQueue}
       LOAN_CACHE_TABLE: ${self:custom.TableNames.${opt:stage}.loansCacheTable}
       ALMA_API_KEY_NAME: ${env:ALMA_API_KEY_NAME}
 

--- a/test/update-loan-test/handler-test.js
+++ b/test/update-loan-test/handler-test.js
@@ -35,39 +35,43 @@ describe('update loan handler tests', () => {
   })
 
   describe('handler method tests', () => {
-    it('should call receiveMessages on the Loans Queue', () => {
-      const receiveMessagesStub = sandbox.stub(Queue.prototype, 'receiveMessages')
-      receiveMessagesStub.resolves(true)
+    // it('should call receiveMessages on the Loans Queue', () => {
+    //   const receiveMessagesStub = sandbox.stub(Queue.prototype, 'receiveMessages')
+    //   receiveMessagesStub.resolves(true)
 
-      wires.push(
-        updateLoanHandler.__set__('handleMessages', () => Promise.resolve()),
-        updateLoanHandler.__set__('updateLoan', () => Promise.resolve()),
-        updateLoanHandler.__set__('deleteMessage', () => Promise.resolve())
-      )
+    //   wires.push(
+    //     updateLoanHandler.__set__('handleMessages', () => Promise.resolve()),
+    //     updateLoanHandler.__set__('updateLoan', () => Promise.resolve()),
+    //     updateLoanHandler.__set__('deleteMessage', () => Promise.resolve())
+    //   )
 
-      return handler()
-        .then(() => {
-          receiveMessagesStub.should.have.been.called
-        })
-    })
+    //   return handler()
+    //     .then(() => {
+    //       receiveMessagesStub.should.have.been.called
+    //     })
+    // })
 
-    it('should call handleMessages with the response of recieveMesages', () => {
-      const receiveMessagesStub = sandbox.stub(Queue.prototype, 'receiveMessages')
-      receiveMessagesStub.resolves([{
+    it('should call handleMessages with the event Records', () => {
+      // const receiveMessagesStub = sandbox.stub(Queue.prototype, 'receiveMessages')
+      // receiveMessagesStub.resolves([{
+      //   Body: JSON.stringify({ test: 'test_id' }),
+      //   ReceiptHandle: 'test_message_handle'
+      // }])
+      const testEvent = { Records: [{
         Body: JSON.stringify({ test: 'test_id' }),
         ReceiptHandle: 'test_message_handle'
-      }])
+      }]}
 
       const handleMessageStub = sandbox.stub()
       handleMessageStub.resolves()
 
       wires.push(
         updateLoanHandler.__set__('handleMessages', handleMessageStub),
-        updateLoanHandler.__set__('updateLoan', () => Promise.resolve()),
-        updateLoanHandler.__set__('deleteMessage', () => Promise.resolve())
+        updateLoanHandler.__set__('updateLoan', () => Promise.resolve())
+        // updateLoanHandler.__set__('deleteMessage', () => Promise.resolve())
       )
 
-      return handler()
+      return handler(testEvent)
         .then(() => {
           handleMessageStub.should.have.been.calledWith([{
             Body: JSON.stringify({ test: 'test_id' }),
@@ -111,8 +115,8 @@ describe('update loan handler tests', () => {
       updateLoanStub.resolves()
 
       wires.push(
-        updateLoanHandler.__set__('updateLoan', updateLoanStub),
-        updateLoanHandler.__set__('deleteMessage', () => Promise.resolve())
+        updateLoanHandler.__set__('updateLoan', updateLoanStub)
+        // updateLoanHandler.__set__('deleteMessage', () => Promise.resolve())
       )
 
       return handleMessages(testMessages)
@@ -123,53 +127,53 @@ describe('update loan handler tests', () => {
         })
     })
 
-    it('should call deleteMessage with each message object', () => {
-      const testReceiptHandles = [uuid(), uuid(), uuid()]
-      const testMessages = [{
-        Body: JSON.stringify({ id: uuid() }),
-        ReceiptHandle: testReceiptHandles[0]
-      }, {
-        Body: JSON.stringify({ id: uuid() }),
-        ReceiptHandle: testReceiptHandles[1]
-      }, {
-        Body: JSON.stringify({ id: uuid() }),
-        ReceiptHandle: testReceiptHandles[2]
-      }]
+    // it('should call deleteMessage with each message object', () => {
+    //   const testReceiptHandles = [uuid(), uuid(), uuid()]
+    //   const testMessages = [{
+    //     Body: JSON.stringify({ id: uuid() }),
+    //     ReceiptHandle: testReceiptHandles[0]
+    //   }, {
+    //     Body: JSON.stringify({ id: uuid() }),
+    //     ReceiptHandle: testReceiptHandles[1]
+    //   }, {
+    //     Body: JSON.stringify({ id: uuid() }),
+    //     ReceiptHandle: testReceiptHandles[2]
+    //   }]
 
-      // const receiveMessagesStub = sandbox.stub(Queue.prototype, 'receiveMessages')
-      // receiveMessagesStub.resolves(testMessages)
+    //   // const receiveMessagesStub = sandbox.stub(Queue.prototype, 'receiveMessages')
+    //   // receiveMessagesStub.resolves(testMessages)
 
-      const deleteMessageStub = sandbox.stub()
-      deleteMessageStub.resolves()
+    //   const deleteMessageStub = sandbox.stub()
+    //   deleteMessageStub.resolves()
 
-      wires.push(
-        updateLoanHandler.__set__('updateLoan', () => Promise.resolve()),
-        updateLoanHandler.__set__('deleteMessage', deleteMessageStub)
-      )
+    //   wires.push(
+    //     updateLoanHandler.__set__('updateLoan', () => Promise.resolve()),
+    //     updateLoanHandler.__set__('deleteMessage', deleteMessageStub)
+    //   )
 
-      return handleMessages(testMessages)
-        .then(() => {
-          testMessages.forEach(message => {
-            deleteMessageStub.should.have.been.calledWith(message)
-          })
-        })
-    })
+    //   return handleMessages(testMessages)
+    //     .then(() => {
+    //       testMessages.forEach(message => {
+    //         deleteMessageStub.should.have.been.calledWith(message)
+    //       })
+    //     })
+    // })
 
     it('should default to an empty message array, and not call updateLoan or deleteMessage', () => {
       const updateLoanStub = sandbox.stub()
       updateLoanStub.resolves()
-      const deleteMessageStub = sandbox.stub()
-      deleteMessageStub.resolves()
+      // const deleteMessageStub = sandbox.stub()
+      // deleteMessageStub.resolves()
 
       wires.push(
-        updateLoanHandler.__set__('updateLoan', updateLoanStub),
-        updateLoanHandler.__set__('deleteMessage', deleteMessageStub)
+        updateLoanHandler.__set__('updateLoan', updateLoanStub)
+        // updateLoanHandler.__set__('deleteMessage', deleteMessageStub)
       )
 
       return handleMessages()
         .then(() => {
           updateLoanStub.should.not.have.been.called
-          deleteMessageStub.should.not.have.been.called
+          // deleteMessageStub.should.not.have.been.called
         })
     })
   })
@@ -195,22 +199,22 @@ describe('update loan handler tests', () => {
     })
   })
 
-  describe('deleteMessage method tests', () => {
-    const deleteMessage = updateLoanHandler.__get__('deleteMessage')
-    it('should call deleteMessage on the loans Queue', () => {
-      const deleteMessageStub = sandbox.stub(Queue.prototype, 'deleteMessage')
-      deleteMessageStub.resolves()
+  // describe('deleteMessage method tests', () => {
+  //   const deleteMessage = updateLoanHandler.__get__('deleteMessage')
+  //   it('should call deleteMessage on the loans Queue', () => {
+  //     const deleteMessageStub = sandbox.stub(Queue.prototype, 'deleteMessage')
+  //     deleteMessageStub.resolves()
 
-      const testHandle = uuid()
+  //     const testHandle = uuid()
 
-      const testMessage = {
-        ReceiptHandle: testHandle
-      }
+  //     const testMessage = {
+  //       ReceiptHandle: testHandle
+  //     }
 
-      return deleteMessage(testMessage)
-        .then(() => {
-          deleteMessageStub.should.have.been.calledWith(testHandle)
-        })
-    })
-  })
+  //     return deleteMessage(testMessage)
+  //       .then(() => {
+  //         deleteMessageStub.should.have.been.calledWith(testHandle)
+  //       })
+  //   })
+  // })
 })

--- a/test/update-loan-test/handler-test.js
+++ b/test/update-loan-test/handler-test.js
@@ -35,28 +35,7 @@ describe('update loan handler tests', () => {
   })
 
   describe('handler method tests', () => {
-    // it('should call receiveMessages on the Loans Queue', () => {
-    //   const receiveMessagesStub = sandbox.stub(Queue.prototype, 'receiveMessages')
-    //   receiveMessagesStub.resolves(true)
-
-    //   wires.push(
-    //     updateLoanHandler.__set__('handleMessages', () => Promise.resolve()),
-    //     updateLoanHandler.__set__('updateLoan', () => Promise.resolve()),
-    //     updateLoanHandler.__set__('deleteMessage', () => Promise.resolve())
-    //   )
-
-    //   return handler()
-    //     .then(() => {
-    //       receiveMessagesStub.should.have.been.called
-    //     })
-    // })
-
     it('should call handleMessages with the event Records', () => {
-      // const receiveMessagesStub = sandbox.stub(Queue.prototype, 'receiveMessages')
-      // receiveMessagesStub.resolves([{
-      //   Body: JSON.stringify({ test: 'test_id' }),
-      //   ReceiptHandle: 'test_message_handle'
-      // }])
       const testEvent = { Records: [{
         Body: JSON.stringify({ test: 'test_id' }),
         ReceiptHandle: 'test_message_handle'
@@ -68,7 +47,6 @@ describe('update loan handler tests', () => {
       wires.push(
         updateLoanHandler.__set__('handleMessages', handleMessageStub),
         updateLoanHandler.__set__('updateLoan', () => Promise.resolve())
-        // updateLoanHandler.__set__('deleteMessage', () => Promise.resolve())
       )
 
       return handler(testEvent)
@@ -108,15 +86,11 @@ describe('update loan handler tests', () => {
         ReceiptHandle: uuid()
       }]
 
-      // const receiveMessagesStub = sandbox.stub(Queue.prototype, 'receiveMessages')
-      // receiveMessagesStub.resolves(testMessages)
-
       const updateLoanStub = sandbox.stub()
       updateLoanStub.resolves()
 
       wires.push(
         updateLoanHandler.__set__('updateLoan', updateLoanStub)
-        // updateLoanHandler.__set__('deleteMessage', () => Promise.resolve())
       )
 
       return handleMessages(testMessages)
@@ -127,53 +101,17 @@ describe('update loan handler tests', () => {
         })
     })
 
-    // it('should call deleteMessage with each message object', () => {
-    //   const testReceiptHandles = [uuid(), uuid(), uuid()]
-    //   const testMessages = [{
-    //     Body: JSON.stringify({ id: uuid() }),
-    //     ReceiptHandle: testReceiptHandles[0]
-    //   }, {
-    //     Body: JSON.stringify({ id: uuid() }),
-    //     ReceiptHandle: testReceiptHandles[1]
-    //   }, {
-    //     Body: JSON.stringify({ id: uuid() }),
-    //     ReceiptHandle: testReceiptHandles[2]
-    //   }]
-
-    //   // const receiveMessagesStub = sandbox.stub(Queue.prototype, 'receiveMessages')
-    //   // receiveMessagesStub.resolves(testMessages)
-
-    //   const deleteMessageStub = sandbox.stub()
-    //   deleteMessageStub.resolves()
-
-    //   wires.push(
-    //     updateLoanHandler.__set__('updateLoan', () => Promise.resolve()),
-    //     updateLoanHandler.__set__('deleteMessage', deleteMessageStub)
-    //   )
-
-    //   return handleMessages(testMessages)
-    //     .then(() => {
-    //       testMessages.forEach(message => {
-    //         deleteMessageStub.should.have.been.calledWith(message)
-    //       })
-    //     })
-    // })
-
     it('should default to an empty message array, and not call updateLoan or deleteMessage', () => {
       const updateLoanStub = sandbox.stub()
       updateLoanStub.resolves()
-      // const deleteMessageStub = sandbox.stub()
-      // deleteMessageStub.resolves()
 
       wires.push(
         updateLoanHandler.__set__('updateLoan', updateLoanStub)
-        // updateLoanHandler.__set__('deleteMessage', deleteMessageStub)
       )
 
       return handleMessages()
         .then(() => {
           updateLoanStub.should.not.have.been.called
-          // deleteMessageStub.should.not.have.been.called
         })
     })
   })
@@ -198,23 +136,4 @@ describe('update loan handler tests', () => {
         })
     })
   })
-
-  // describe('deleteMessage method tests', () => {
-  //   const deleteMessage = updateLoanHandler.__get__('deleteMessage')
-  //   it('should call deleteMessage on the loans Queue', () => {
-  //     const deleteMessageStub = sandbox.stub(Queue.prototype, 'deleteMessage')
-  //     deleteMessageStub.resolves()
-
-  //     const testHandle = uuid()
-
-  //     const testMessage = {
-  //       ReceiptHandle: testHandle
-  //     }
-
-  //     return deleteMessage(testMessage)
-  //       .then(() => {
-  //         deleteMessageStub.should.have.been.calledWith(testHandle)
-  //       })
-  //   })
-  // })
 })

--- a/test/update-user-test/handler-test.js
+++ b/test/update-user-test/handler-test.js
@@ -35,29 +35,34 @@ describe('update user handler tests', () => {
   })
 
   describe('handler method tests', () => {
-    it('should call receiveMessages on the Users Queue', () => {
-      const receiveMessagesStub = sandbox.stub(Queue.prototype, 'receiveMessages')
-      receiveMessagesStub.resolves(true)
+    // it('should call receiveMessages on the Users Queue', () => {
+    //   const receiveMessagesStub = sandbox.stub(Queue.prototype, 'receiveMessages')
+    //   receiveMessagesStub.resolves(true)
 
-      wires.push(
-        updateUserHandler.__set__('handleMessages', () => Promise.resolve()),
-        updateUserHandler.__set__('updateUser', () => Promise.resolve()),
-        updateUserHandler.__set__('handleLoansAndRequests', () => Promise.resolve()),
-        updateUserHandler.__set__('deleteMessage', () => Promise.resolve())
-      )
+    //   wires.push(
+    //     updateUserHandler.__set__('handleMessages', () => Promise.resolve()),
+    //     updateUserHandler.__set__('updateUser', () => Promise.resolve()),
+    //     updateUserHandler.__set__('handleLoansAndRequests', () => Promise.resolve()),
+    //     updateUserHandler.__set__('deleteMessage', () => Promise.resolve())
+    //   )
 
-      return handler()
-        .then(() => {
-          receiveMessagesStub.should.have.been.called
-        })
-    })
+    //   return handler()
+    //     .then(() => {
+    //       receiveMessagesStub.should.have.been.called
+    //     })
+    // })
 
-    it('should call handleMessages with the response of recieveMesages', () => {
-      const receiveMessagesStub = sandbox.stub(Queue.prototype, 'receiveMessages')
-      receiveMessagesStub.resolves([{
+    it('should call handleMessages with the event Records', () => {
+      // const receiveMessagesStub = sandbox.stub(Queue.prototype, 'receiveMessages')
+      // receiveMessagesStub.resolves([{
+      //   Body: 'test_message_body',
+      //   ReceiptHandle: 'test_message_handle'
+      // }])
+
+      const testEvent = { Records: [{
         Body: 'test_message_body',
         ReceiptHandle: 'test_message_handle'
-      }])
+      }]}
 
       const handleMessageStub = sandbox.stub()
       handleMessageStub.resolves()
@@ -65,11 +70,11 @@ describe('update user handler tests', () => {
       wires.push(
         updateUserHandler.__set__('handleMessages', handleMessageStub),
         updateUserHandler.__set__('updateUser', () => Promise.resolve()),
-        updateUserHandler.__set__('handleLoansAndRequests', () => Promise.resolve()),
-        updateUserHandler.__set__('deleteMessage', () => Promise.resolve())
+        updateUserHandler.__set__('handleLoansAndRequests', () => Promise.resolve())
+        // updateUserHandler.__set__('deleteMessage', () => Promise.resolve())
       )
 
-      return handler()
+      return handler(testEvent)
         .then(() => {
           handleMessageStub.should.have.been.calledWith([{
             Body: 'test_message_body',
@@ -105,19 +110,20 @@ describe('update user handler tests', () => {
         ReceiptHandle: uuid()
       }]
 
-      const receiveMessagesStub = sandbox.stub(Queue.prototype, 'receiveMessages')
-      receiveMessagesStub.resolves(testMessages)
+      // const receiveMessagesStub = sandbox.stub(Queue.prototype, 'receiveMessages')
+      // receiveMessagesStub.resolves(testMessages)
+      const testEvent = { Records: testMessages }
 
       const updateUserStub = sandbox.stub()
       updateUserStub.resolves()
 
       wires.push(
         updateUserHandler.__set__('updateUser', updateUserStub),
-        updateUserHandler.__set__('handleLoansAndRequests', () => Promise.resolve()),
-        updateUserHandler.__set__('deleteMessage', () => Promise.resolve())
+        updateUserHandler.__set__('handleLoansAndRequests', () => Promise.resolve())
+        // updateUserHandler.__set__('deleteMessage', () => Promise.resolve())
       )
 
-      return handler()
+      return handler(testEvent)
         .then(() => {
           testMessages.forEach(message => {
             updateUserStub.should.have.been.calledWith(message.Body)
@@ -125,54 +131,55 @@ describe('update user handler tests', () => {
         })
     })
 
-    it('should call deleteMessage with each message object', () => {
-      const testReceiptHandles = [uuid(), uuid(), uuid()]
-      const testMessages = [{
-        Body: uuid(),
-        ReceiptHandle: testReceiptHandles[0]
-      }, {
-        Body: uuid(),
-        ReceiptHandle: testReceiptHandles[1]
-      }, {
-        Body: uuid(),
-        ReceiptHandle: testReceiptHandles[2]
-      }]
+    // it('should call deleteMessage with each message object', () => {
+    //   const testReceiptHandles = [uuid(), uuid(), uuid()]
+    //   const testMessages = [{
+    //     Body: uuid(),
+    //     ReceiptHandle: testReceiptHandles[0]
+    //   }, {
+    //     Body: uuid(),
+    //     ReceiptHandle: testReceiptHandles[1]
+    //   }, {
+    //     Body: uuid(),
+    //     ReceiptHandle: testReceiptHandles[2]
+    //   }]
 
-      const receiveMessagesStub = sandbox.stub(Queue.prototype, 'receiveMessages')
-      receiveMessagesStub.resolves(testMessages)
+    //   // const receiveMessagesStub = sandbox.stub(Queue.prototype, 'receiveMessages')
+    //   // receiveMessagesStub.resolves(testMessages)
+    //   const testEvent = { Records: testMessages }
 
-      const deleteMessageStub = sandbox.stub()
-      deleteMessageStub.resolves()
+    //   const deleteMessageStub = sandbox.stub()
+    //   deleteMessageStub.resolves()
 
-      wires.push(
-        updateUserHandler.__set__('updateUser', () => Promise.resolve()),
-        updateUserHandler.__set__('handleLoansAndRequests', () => Promise.resolve()),
-        updateUserHandler.__set__('deleteMessage', deleteMessageStub)
-      )
+    //   wires.push(
+    //     updateUserHandler.__set__('updateUser', () => Promise.resolve()),
+    //     updateUserHandler.__set__('handleLoansAndRequests', () => Promise.resolve()),
+    //     updateUserHandler.__set__('deleteMessage', deleteMessageStub)
+    //   )
 
-      return handler()
-        .then(() => {
-          testMessages.forEach(message => {
-            deleteMessageStub.should.have.been.calledWith(message)
-          })
-        })
-    })
+    //   return handler(testEvent)
+    //     .then(() => {
+    //       testMessages.forEach(message => {
+    //         deleteMessageStub.should.have.been.calledWith(message)
+    //       })
+    //     })
+    // })
 
-    it('should default to an empty message array, and not call updateUser or deleteMessage', () => {
+    it('should default to an empty message array, and not call updateUser', () => {
       const updateUserStub = sandbox.stub()
       updateUserStub.resolves()
-      const deleteMessageStub = sandbox.stub()
-      deleteMessageStub.resolves()
+      // const deleteMessageStub = sandbox.stub()
+      // deleteMessageStub.resolves()
 
       wires.push(
-        updateUserHandler.__set__('updateUser', updateUserStub),
-        updateUserHandler.__set__('deleteMessage', deleteMessageStub)
+        updateUserHandler.__set__('updateUser', updateUserStub)
+        // updateUserHandler.__set__('deleteMessage', deleteMessageStub)
       )
 
       return handleMessages()
         .then(() => {
           updateUserStub.should.not.have.been.called
-          deleteMessageStub.should.not.have.been.called
+          // deleteMessageStub.should.not.have.been.called
         })
     })
   })
@@ -310,22 +317,22 @@ describe('update user handler tests', () => {
     })
   })
 
-  describe('deleteMessage method tests', () => {
-    const deleteMessage = updateUserHandler.__get__('deleteMessage')
-    it('should call deleteMessage on the users Queue', () => {
-      const deleteMessageStub = sandbox.stub(Queue.prototype, 'deleteMessage')
-      deleteMessageStub.resolves()
+  // describe('deleteMessage method tests', () => {
+  //   const deleteMessage = updateUserHandler.__get__('deleteMessage')
+  //   it('should call deleteMessage on the users Queue', () => {
+  //     const deleteMessageStub = sandbox.stub(Queue.prototype, 'deleteMessage')
+  //     deleteMessageStub.resolves()
 
-      const testHandle = uuid()
+  //     const testHandle = uuid()
 
-      const testMessage = {
-        ReceiptHandle: testHandle
-      }
+  //     const testMessage = {
+  //       ReceiptHandle: testHandle
+  //     }
 
-      return deleteMessage(testMessage)
-        .then(() => {
-          deleteMessageStub.should.have.been.calledWith(testHandle)
-        })
-    })
-  })
+  //     return deleteMessage(testMessage)
+  //       .then(() => {
+  //         deleteMessageStub.should.have.been.calledWith(testHandle)
+  //       })
+  //   })
+  // })
 })

--- a/test/update-user-test/handler-test.js
+++ b/test/update-user-test/handler-test.js
@@ -35,30 +35,7 @@ describe('update user handler tests', () => {
   })
 
   describe('handler method tests', () => {
-    // it('should call receiveMessages on the Users Queue', () => {
-    //   const receiveMessagesStub = sandbox.stub(Queue.prototype, 'receiveMessages')
-    //   receiveMessagesStub.resolves(true)
-
-    //   wires.push(
-    //     updateUserHandler.__set__('handleMessages', () => Promise.resolve()),
-    //     updateUserHandler.__set__('updateUser', () => Promise.resolve()),
-    //     updateUserHandler.__set__('handleLoansAndRequests', () => Promise.resolve()),
-    //     updateUserHandler.__set__('deleteMessage', () => Promise.resolve())
-    //   )
-
-    //   return handler()
-    //     .then(() => {
-    //       receiveMessagesStub.should.have.been.called
-    //     })
-    // })
-
     it('should call handleMessages with the event Records', () => {
-      // const receiveMessagesStub = sandbox.stub(Queue.prototype, 'receiveMessages')
-      // receiveMessagesStub.resolves([{
-      //   Body: 'test_message_body',
-      //   ReceiptHandle: 'test_message_handle'
-      // }])
-
       const testEvent = { Records: [{
         Body: 'test_message_body',
         ReceiptHandle: 'test_message_handle'
@@ -71,7 +48,6 @@ describe('update user handler tests', () => {
         updateUserHandler.__set__('handleMessages', handleMessageStub),
         updateUserHandler.__set__('updateUser', () => Promise.resolve()),
         updateUserHandler.__set__('handleLoansAndRequests', () => Promise.resolve())
-        // updateUserHandler.__set__('deleteMessage', () => Promise.resolve())
       )
 
       return handler(testEvent)
@@ -110,8 +86,6 @@ describe('update user handler tests', () => {
         ReceiptHandle: uuid()
       }]
 
-      // const receiveMessagesStub = sandbox.stub(Queue.prototype, 'receiveMessages')
-      // receiveMessagesStub.resolves(testMessages)
       const testEvent = { Records: testMessages }
 
       const updateUserStub = sandbox.stub()
@@ -120,7 +94,6 @@ describe('update user handler tests', () => {
       wires.push(
         updateUserHandler.__set__('updateUser', updateUserStub),
         updateUserHandler.__set__('handleLoansAndRequests', () => Promise.resolve())
-        // updateUserHandler.__set__('deleteMessage', () => Promise.resolve())
       )
 
       return handler(testEvent)
@@ -131,55 +104,17 @@ describe('update user handler tests', () => {
         })
     })
 
-    // it('should call deleteMessage with each message object', () => {
-    //   const testReceiptHandles = [uuid(), uuid(), uuid()]
-    //   const testMessages = [{
-    //     Body: uuid(),
-    //     ReceiptHandle: testReceiptHandles[0]
-    //   }, {
-    //     Body: uuid(),
-    //     ReceiptHandle: testReceiptHandles[1]
-    //   }, {
-    //     Body: uuid(),
-    //     ReceiptHandle: testReceiptHandles[2]
-    //   }]
-
-    //   // const receiveMessagesStub = sandbox.stub(Queue.prototype, 'receiveMessages')
-    //   // receiveMessagesStub.resolves(testMessages)
-    //   const testEvent = { Records: testMessages }
-
-    //   const deleteMessageStub = sandbox.stub()
-    //   deleteMessageStub.resolves()
-
-    //   wires.push(
-    //     updateUserHandler.__set__('updateUser', () => Promise.resolve()),
-    //     updateUserHandler.__set__('handleLoansAndRequests', () => Promise.resolve()),
-    //     updateUserHandler.__set__('deleteMessage', deleteMessageStub)
-    //   )
-
-    //   return handler(testEvent)
-    //     .then(() => {
-    //       testMessages.forEach(message => {
-    //         deleteMessageStub.should.have.been.calledWith(message)
-    //       })
-    //     })
-    // })
-
     it('should default to an empty message array, and not call updateUser', () => {
       const updateUserStub = sandbox.stub()
       updateUserStub.resolves()
-      // const deleteMessageStub = sandbox.stub()
-      // deleteMessageStub.resolves()
 
       wires.push(
         updateUserHandler.__set__('updateUser', updateUserStub)
-        // updateUserHandler.__set__('deleteMessage', deleteMessageStub)
       )
 
       return handleMessages()
         .then(() => {
           updateUserStub.should.not.have.been.called
-          // deleteMessageStub.should.not.have.been.called
         })
     })
   })
@@ -316,23 +251,4 @@ describe('update user handler tests', () => {
         })
     })
   })
-
-  // describe('deleteMessage method tests', () => {
-  //   const deleteMessage = updateUserHandler.__get__('deleteMessage')
-  //   it('should call deleteMessage on the users Queue', () => {
-  //     const deleteMessageStub = sandbox.stub(Queue.prototype, 'deleteMessage')
-  //     deleteMessageStub.resolves()
-
-  //     const testHandle = uuid()
-
-  //     const testMessage = {
-  //       ReceiptHandle: testHandle
-  //     }
-
-  //     return deleteMessage(testMessage)
-  //       .then(() => {
-  //         deleteMessageStub.should.have.been.calledWith(testHandle)
-  //       })
-  //   })
-  // })
 })


### PR DESCRIPTION
This fixes the SQS event trigger for the `update-user` and `update-loan` lambdas, removing the requirement to receive and delete messages from the queues within the lambdas.