### PR TITLE
SQS Dead Letter Queues

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -57,6 +57,7 @@ resources:
       Type: AWS::SQS::Queue
       Properties:
         QueueName: ${self:service}-${opt:stage}-loansQueue
+
     requestsQueue:
       Type: AWS::SQS::Queue
       Properties:
@@ -65,6 +66,11 @@ resources:
       type: AWS::SQS::Queue
       Properties:
         QueueName: ${self:service}-${opt:stage}-loansDLQ
+        MessageRetentionPeriod: 1209600
+   requestsDLQ:
+      type: AWS::SQS::Queue
+      Properties:
+        QueueName: ${self:service}-${opt:stage}-requestsDLQ
         MessageRetentionPeriod: 1209600
 
 custom:
@@ -98,6 +104,8 @@ custom:
     DLQs:
       loansDLQ:
         "Fn::GetAtt": ["loansDLQ", "Arn"]
+      requestsDLQ:
+        "Fn::GetAtt": ["requestsDLQ", "Arn"]
 
   QueueUrls:
     stg:
@@ -115,3 +123,5 @@ custom:
     DLQs:
       loansDLQ:
         Ref: loansDLQ
+      requestsDLQ:
+        Ref: requestsDLQ

--- a/serverless.yml
+++ b/serverless.yml
@@ -61,11 +61,6 @@ resources:
       Type: AWS::SQS::Queue
       Properties:
         QueueName: ${self:service}-${opt:stage}-requestsQueue
-    usersDLQ:
-      type: AWS::SQS::Queue
-      Properties:
-        QueueName: ${self:service}-${opt:stage}-usersDLQ
-        MessageRetentionPeriod: 1209600
     loansDLQ:
       type: AWS::SQS::Queue
       Properties:
@@ -101,8 +96,6 @@ custom:
       requestsQueue:
         "Fn::GetAtt": ["requestsQueue", "Arn"]
     DLQs:
-      usersDLQ:
-        "Fn::GetAtt": ["usersDLQ", "Arn"]
       loansDLQ:
         "Fn::GetAtt": ["loansDLQ", "Arn"]
 
@@ -120,7 +113,5 @@ custom:
       requestsQueue:
         Ref: requestsQueue
     DLQs:
-      usersDLQ:
-        Ref: usersDLQ
       loansDLQ:
         Ref: loansDLQ

--- a/serverless.yml
+++ b/serverless.yml
@@ -57,11 +57,16 @@ resources:
       Type: AWS::SQS::Queue
       Properties:
         QueueName: ${self:service}-${opt:stage}-loansQueue
-
+        RedrivePolicy:
+          deadLetterTargetArn: ${self:custom.queueArns.DLQs.loansDLQ}
+          maxReceiveCount: 3
     requestsQueue:
       Type: AWS::SQS::Queue
       Properties:
         QueueName: ${self:service}-${opt:stage}-requestsQueue
+        RedrivePolicy:
+          deadLetterTargetArn: ${self:custom.queueArns.DLQs.requestsDLQ}
+          maxReceiveCount: 3
     loansDLQ:
       type: AWS::SQS::Queue
       Properties:

--- a/serverless.yml
+++ b/serverless.yml
@@ -61,6 +61,16 @@ resources:
       Type: AWS::SQS::Queue
       Properties:
         QueueName: ${self:service}-${opt:stage}-requestsQueue
+    usersDLQ:
+      type: AWS::SQS::Queue
+      Properties:
+        QueueName: ${self:service}-${opt:stage}-usersDLQ
+        MessageRetentionPeriod: 1209600
+    loansDLQ:
+      type: AWS::SQS::Queue
+      Properties:
+        QueueName: ${self:service}-${opt:stage}-loansDLQ
+        MessageRetentionPeriod: 1209600
 
 custom:
   TableArns:
@@ -90,6 +100,11 @@ custom:
         "Fn::GetAtt": ["loansQueue", "Arn"]
       requestsQueue:
         "Fn::GetAtt": ["requestsQueue", "Arn"]
+    DLQs:
+      usersDLQ:
+        "Fn::GetAtt": ["usersDLQ", "Arn"]
+      loansDLQ:
+        "Fn::GetAtt": ["loansDLQ", "Arn"]
 
   QueueUrls:
     stg:
@@ -104,3 +119,8 @@ custom:
         Ref: loansQueue
       requestsQueue:
         Ref: requestsQueue
+    DLQs:
+      usersDLQ:
+        Ref: usersDLQ
+      loansDLQ:
+        Ref: loansDLQ


### PR DESCRIPTION
This sets up SQS dead letter queues for the `loans` and `requests` queues, with redrive policies to receive messages a maximum of 3 times, then send them to the dead letter queues.