### PR TITLE
Fix more config typos

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -58,14 +58,14 @@ resources:
       Properties:
         QueueName: ${self:service}-${opt:stage}-loansQueue
         RedrivePolicy:
-          deadLetterTargetArn: ${self:custom.queueArns.DLQs.loansDLQ}
+          deadLetterTargetArn: ${self:custom.QueueArns.DLQs.loansDLQ}
           maxReceiveCount: 3
     requestsQueue:
       Type: AWS::SQS::Queue
       Properties:
         QueueName: ${self:service}-${opt:stage}-requestsQueue
         RedrivePolicy:
-          deadLetterTargetArn: ${self:custom.queueArns.DLQs.requestsDLQ}
+          deadLetterTargetArn: ${self:custom.QueueArns.DLQs.requestsDLQ}
           maxReceiveCount: 3
     loansDLQ:
       Type: AWS::SQS::Queue


### PR DESCRIPTION
This fixes the typo `queueArns` in serverless.yml resource reference. Changes to `QueueArns`.