### PR TITLE
Fix Fee Queue URL Reference

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -181,14 +181,20 @@ custom:
         Ref: loansQueue
       requestsQueue:
         Ref: requestsQueue
+      feesQueue:
+        Ref: feesQueue
     prod:
       usersQueue: ${env:USER_QUEUE_URL_PROD}
       loansQueue:
         Ref: loansQueue
       requestsQueue:
         Ref: requestsQueue
+      feesQueue:
+        Ref: feesQueue
     DLQs:
       loansDLQ:
         Ref: loansDLQ
       requestsDLQ:
         Ref: requestsDLQ
+      feesDLQ:
+        Ref: feesDLQ


### PR DESCRIPTION
This fixes invalid references to the `Fees` queue in `serverless.yml` due to the reference `custom.QueueUrls.${opt:stage}.feesQueue` being absent. 