### PR TITLE
Fix Fee Handler API key

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -69,6 +69,7 @@ functions:
           arn: ${self:custom.QueueArns.${opt:stage}.feesQueue}
     environment:
       FEE_CACHE_TABLE: ${self:custom.TableNames.${opt:stage}.feesCacheTable}
+      ALMA_API_KEY_NAME: ${env:ALMA_API_KEY_NAME}
 
 resources:
   Resources:


### PR DESCRIPTION
This fixes an issue with the `update-fee` handler where it was not provided with the Alma API key name, so could not retrieve the API key from SSM.