### PR TITLE
Update Packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,8 +5,8 @@
   "requires": true,
   "dependencies": {
     "@lulibrary/lag-alma-utils": {
-      "version": "git+ssh://git@github.com/lulibrary/LAG-Alma-Utils.git#14d97c5e7dd495e29066b47d75cfd0bea84777ea",
-      "from": "git+ssh://git@github.com/lulibrary/LAG-Alma-Utils.git#v0.5.3",
+      "version": "git+ssh://git@github.com/lulibrary/LAG-Alma-Utils.git#5f8e7131055485774522c6dc10c86476df5aa9c1",
+      "from": "git+ssh://git@github.com/lulibrary/LAG-Alma-Utils.git#v0.7.0",
       "requires": {
         "dynamoose": "^0.8.7",
         "lodash.chunk": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "sinon-chai": "^3.0.0"
   },
   "dependencies": {
-    "@lulibrary/lag-alma-utils": "git+ssh://git@github.com/lulibrary/LAG-Alma-Utils.git#v0.5.3",
+    "@lulibrary/lag-alma-utils": "git+ssh://git@github.com/lulibrary/LAG-Alma-Utils.git#v0.7.0",
     "@lulibrary/lag-utils": "git+ssh://git@github.com/lulibrary/LAG-Utils.git#v0.4.0",
     "alma-api-wrapper": "git+ssh://git@github.com/lulibrary/node-alma-api-wrapper.git#v0.2.0"
   }

--- a/test/update-fee-test/handler-test.js
+++ b/test/update-fee-test/handler-test.js
@@ -217,7 +217,9 @@ describe('update fee handler tests', () => {
         apiStub.withArgs(ID).resolves({
           data: {
             id: ID,
-            user_primary_id: testUserID
+            user_primary_id: {
+              value: testUserID
+            }
           }
         })
       })
@@ -242,7 +244,11 @@ describe('update fee handler tests', () => {
                     S: ID
                   },
                   user_primary_id: {
-                    S: testUserID
+                    M: {
+                      value: {
+                        S: testUserID
+                      }
+                    }
                   },
                   expiry_date: {
                     N: `${2 * 7 * 24 * 60 * 60}`


### PR DESCRIPTION
This updates the service to the latest version of `LAG-Alma-Utils`, to include the correct Alma Fee schema, and forced lowercase user IDs.