### PR TITLE
Enable TTL

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -121,6 +121,9 @@ resources:
           ProvisionedThroughput:
             ReadCapacityUnits: 5
             WriteCapacityUnits: 5
+          TimeToLiveSpecification:
+            AttributeName: expiry_date
+            Enabled: true
 
 
 custom:


### PR DESCRIPTION
This enables the DynamoDB TTL property on the `Fee` cache table, to automatically remove expired records