### PR TITLE
Dynamic Table ARN Generation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4638,6 +4638,12 @@
       "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
       "dev": true
     },
+    "serverless-pseudo-parameters": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/serverless-pseudo-parameters/-/serverless-pseudo-parameters-2.1.0.tgz",
+      "integrity": "sha512-RnsvKBAjqp0gm/WWKizsxsHtok9JHZ+U7/JvRCFrst68z7b6Ktu8EDI89CyFQYjU2b4w1zSiiCYI95UbZMIIxA==",
+      "dev": true
+    },
     "shebang-command": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "mock-require": "^3.0.2",
     "nyc": "^11.6.0",
     "rewire": "^4.0.1",
+    "serverless-pseudo-parameters": "^2.1.0",
     "sinon": "^5.0.2",
     "sinon-chai": "^3.0.0"
   },

--- a/serverless.yml
+++ b/serverless.yml
@@ -129,15 +129,15 @@ resources:
 custom:
   TableArns:
     stg:
-      usersCacheTable: ${env:USER_CACHE_TABLE_ARN_STG}
-      loansCacheTable: ${env:LOAN_CACHE_TABLE_ARN_STG}
-      requestsCacheTable: ${env:REQUEST_CACHE_TABLE_ARN_STG}
+      usersCacheTable: arn:aws:dynamodb:#{AWS::Region}:#{AWS:AccountId}:table/${env:USER_CACHE_TABLE_NAME_STG}
+      loansCacheTable: arn:aws:dynamodb:#{AWS::Region}:#{AWS:AccountId}:table/${env:LOAN_CACHE_TABLE_NAME_STG}
+      requestsCacheTable: arn:aws:dynamodb:#{AWS::Region}:#{AWS:AccountId}:table/${env:REQUEST_CACHE_TABLE_NAME_STG}
       feesCacheTable:
         "Fn::GetAtt": [feeCacheTable, Arn]
     prod:
-      usersCacheTable: ${env:USER_CACHE_TABLE_ARN_PROD}
-      loansCacheTable: ${env:LOAN_CACHE_TABLE_ARN_PROD}
-      requestsCacheTable: ${env:REQUEST_CACHE_TABLE_ARN_PROD}
+      usersCacheTable: arn:aws:dynamodb:#{AWS::Region}:#{AWS:AccountId}:table/${env:USER_CACHE_TABLE_NAME_PROD}
+      loansCacheTable: arn:aws:dynamodb:#{AWS::Region}:#{AWS:AccountId}:table/${env:LOAN_CACHE_TABLE_NAME_PROD}
+      requestsCacheTable: arn:aws:dynamodb:#{AWS::Region}:#{AWS:AccountId}:table/${env:REQUEST_CACHE_TABLE_NAME_PROD}
       feesCacheTable:
         "Fn::GetAtt": [feeCacheTable, Arn]
   TableNames:
@@ -202,3 +202,6 @@ custom:
         Ref: requestsDLQ
       feesDLQ:
         Ref: feesDLQ
+
+plugins:
+  - serverless-pseudo-parameters


### PR DESCRIPTION
This changes the table ARNs in `serverless.yml` to be generated from the table name environment variables, and the AWS region and account ID, instead of being passed in as separate environment variables.