### PR TITLE
Dynamic API Key ARN

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -32,7 +32,7 @@ provider:
       Action:
         - ssm:GetParameter
       Resource:
-        - ${env:ALMA_API_KEY_ARN}
+        - aws:arn:ssm:${opt:region}:#{AWS::AccountId}:parameter${env:ALMA_API_KEY_NAME}
 
 functions:
   updateUser:


### PR DESCRIPTION
This changes the ARN for the Alma API key SSM parameter to be dynamically generated from the `ALMA_API_KEY_NAME` environment variable