### PR TITLE
Fix Typo in SSM parameter ARN

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -32,7 +32,7 @@ provider:
       Action:
         - ssm:GetParameter
       Resource:
-        - aws:arn:ssm:${opt:region}:#{AWS::AccountId}:parameter${env:ALMA_API_KEY_NAME}
+        - arn:aws:ssm:${opt:region}:#{AWS::AccountId}:parameter${env:ALMA_API_KEY_NAME}
 
 functions:
   updateUser:


### PR DESCRIPTION
This fixes a typo where the SSM parameter ARN was incorrectly prefixed as `aws:arn...` instead of `arn:aws...`